### PR TITLE
Removed repo-root from index.adoc

### DIFF
--- a/spring-cloud-stream-app-starters-docs/src/main/asciidoc/index.adoc
+++ b/spring-cloud-stream-app-starters-docs/src/main/asciidoc/index.adoc
@@ -7,7 +7,7 @@ Sabby Anandan, Artem Bilan, Marius Bogoevici, Eric Bottard, Mark Fisher, Ilayape
 :numbered:
 :icons: font
 :hide-uri-scheme:
-:repo-root: ../../../../
+
 // ======================================================================================
 
 = Reference Guide

--- a/spring-cloud-stream-app-starters-docs/src/main/asciidoc/processors.adoc
+++ b/spring-cloud-stream-app-starters-docs/src/main/asciidoc/processors.adoc
@@ -2,32 +2,34 @@
 == Processors
 
 :leveloffset: +2
+:app-starters-root:  https://raw.githubusercontent.com/spring-cloud/spring-cloud-stream-app-starters/master
+
 [[spring-cloud-stream-modules-bridge-processor]]
-include::{repo-root}/processor/spring-cloud-starter-stream-processor-bridge/README.adoc[tags=ref-doc]
+include::{app-starters-root}/processor/spring-cloud-starter-stream-processor-bridge/README.adoc[tags=ref-doc]
 
 [[spring-cloud-stream-modules-filter-processor]]
-include::{repo-root}/processor/spring-cloud-starter-stream-processor-filter/README.adoc[tags=ref-doc]
+include::{app-starters-root}/processor/spring-cloud-starter-stream-processor-filter/README.adoc[tags=ref-doc]
 
 [[spring-cloud-stream-modules-groovy-filter-processor]]
-include::{repo-root}/processor/spring-cloud-starter-stream-processor-groovy-filter/README.adoc[tags=ref-doc]
+include::{app-starters-root}/processor/spring-cloud-starter-stream-processor-groovy-filter/README.adoc[tags=ref-doc]
 
 [[spring-cloud-stream-modules-groovy-transform-processor]]
-include::{repo-root}/processor/spring-cloud-starter-stream-processor-groovy-transform/README.adoc[tags=ref-doc]
+include::{app-starters-root}/processor/spring-cloud-starter-stream-processor-groovy-transform/README.adoc[tags=ref-doc]
 
 [[spring-cloud-stream-modules-httpclient-processor]]
-include::{repo-root}/processor/spring-cloud-starter-stream-processor-httpclient/README.adoc[tags=ref-doc]
+include::{app-starters-root}/processor/spring-cloud-starter-stream-processor-httpclient/README.adoc[tags=ref-doc]
 
 [[spring-cloud-stream-modules-pmml-processor]]
-include::{repo-root}/processor/spring-cloud-starter-stream-processor-pmml/README.adoc[tags=ref-doc]
+include::{app-starters-root}/processor/spring-cloud-starter-stream-processor-pmml/README.adoc[tags=ref-doc]
 
 [[spring-cloud-stream-modules-scriptable-transform]]
-include::{repo-root}/processor/spring-cloud-starter-stream-processor-scriptable-transform/README.adoc[tags=ref-doc]
+include::{app-starters-root}/processor/spring-cloud-starter-stream-processor-scriptable-transform/README.adoc[tags=ref-doc]
 
 [[spring-cloud-stream-modules-splitter]]
-include::{repo-root}/processor/spring-cloud-starter-stream-processor-splitter/README.adoc[tags=ref-doc]
+include::{app-starters-root}/processor/spring-cloud-starter-stream-processor-splitter/README.adoc[tags=ref-doc]
 
 [[spring-clound-stream-modules-transform-processor]]
-include::{repo-root}/processor/spring-cloud-starter-stream-processor-transform/README.adoc[tags=ref-doc]
+include::{app-starters-root}/processor/spring-cloud-starter-stream-processor-transform/README.adoc[tags=ref-doc]
 
 :leveloffset: -2
 

--- a/spring-cloud-stream-app-starters-docs/src/main/asciidoc/sinks.adoc
+++ b/spring-cloud-stream-app-starters-docs/src/main/asciidoc/sinks.adoc
@@ -2,53 +2,55 @@
 == Sinks
 
 :leveloffset: +2
+:app-starters-root:  https://raw.githubusercontent.com/spring-cloud/spring-cloud-stream-app-starters/master
+
 
 [[spring-cloud-stream-modules-cassandra-sink]]
-include::{repo-root}/cassandra/spring-cloud-starter-stream-sink-cassandra/README.adoc[tags=ref-doc]
+include::{app-starters-root}/cassandra/spring-cloud-starter-stream-sink-cassandra/README.adoc[tags=ref-doc]
 
 [[spring-cloud-stream-modules-counter-sink]]
-include::{repo-root}/metrics/spring-cloud-starter-stream-sink-counter/README.adoc[tags=ref-doc]
+include::{app-starters-root}/metrics/spring-cloud-starter-stream-sink-counter/README.adoc[tags=ref-doc]
 
 [[spring-cloud-stream-modules-field-value-counter-sink]]
-include::{repo-root}/metrics/spring-cloud-starter-stream-sink-field-value-counter/README.adoc[tags=ref-doc]
+include::{app-starters-root}/metrics/spring-cloud-starter-stream-sink-field-value-counter/README.adoc[tags=ref-doc]
 
 [[spring-cloud-stream-modules-file-sink]]
-include::{repo-root}/file/spring-cloud-starter-stream-sink-file/README.adoc[tags=ref-doc]
+include::{app-starters-root}/file/spring-cloud-starter-stream-sink-file/README.adoc[tags=ref-doc]
 
 [[spring-cloud-stream-modules-ftp-sink]]
-include::{repo-root}/ftp/spring-cloud-starter-stream-sink-ftp/README.adoc[tags=ref-doc]
+include::{app-starters-root}/ftp/spring-cloud-starter-stream-sink-ftp/README.adoc[tags=ref-doc]
 
 [[spring-cloud-stream-modules-gemfire-sink]]
-include::{repo-root}/gemfire/spring-cloud-starter-stream-sink-gemfire/README.adoc[tags=ref-doc]
+include::{app-starters-root}/gemfire/spring-cloud-starter-stream-sink-gemfire/README.adoc[tags=ref-doc]
 
 [[spring-cloud-stream-modules-gpfdist-sink]]
-include::{repo-root}/gpfdist/spring-cloud-starter-stream-sink-gpfdist/README.adoc[tags=ref-doc]
+include::{app-starters-root}/gpfdist/spring-cloud-starter-stream-sink-gpfdist/README.adoc[tags=ref-doc]
 
 [[spring-cloud-stream-modules-hdfs-sink]]
-include::{repo-root}/hdfs/spring-cloud-starter-stream-sink-hdfs/README.adoc[tags=ref-doc]
+include::{app-starters-root}/hdfs/spring-cloud-starter-stream-sink-hdfs/README.adoc[tags=ref-doc]
 
 [[spring-cloud-stream-modules-jdbc-sink]]
-include::{repo-root}/jdbc/spring-cloud-starter-stream-sink-jdbc/README.adoc[tags=ref-doc]
+include::{app-starters-root}/jdbc/spring-cloud-starter-stream-sink-jdbc/README.adoc[tags=ref-doc]
 
 [[spring-cloud-stream-modules-log-sink]]
-include::{repo-root}/log/spring-cloud-starter-stream-sink-log/README.adoc[tags=ref-doc]
+include::{app-starters-root}/log/spring-cloud-starter-stream-sink-log/README.adoc[tags=ref-doc]
 
 [[spring-cloud-stream-modules-rabbit-sink]]
-include::{repo-root}/rabbit/spring-cloud-starter-stream-sink-rabbit/README.adoc[tags=ref-doc]
+include::{app-starters-root}/rabbit/spring-cloud-starter-stream-sink-rabbit/README.adoc[tags=ref-doc]
 
 [[spring-cloud-stream-modules-redis-sink]]
-include::{repo-root}/redis/spring-cloud-starter-stream-sink-redis/README.adoc[tags=ref-doc]
+include::{app-starters-root}/redis/spring-cloud-starter-stream-sink-redis/README.adoc[tags=ref-doc]
 
 [[spring-cloud-stream-modules-router-sink]]
-include::{repo-root}/router/spring-cloud-starter-stream-sink-router/README.adoc[tags=ref-doc]
+include::{app-starters-root}/router/spring-cloud-starter-stream-sink-router/README.adoc[tags=ref-doc]
 
 [[spring-cloud-stream-modules-tcp-sink]]
-include::{repo-root}/tcp/spring-cloud-starter-stream-sink-tcp/README.adoc[tags=ref-doc]
+include::{app-starters-root}/tcp/spring-cloud-starter-stream-sink-tcp/README.adoc[tags=ref-doc]
 
 [[spring-cloud-stream-modules-throughput-sink]]
-include::{repo-root}/testing/spring-cloud-starter-stream-sink-throughput/README.adoc[tags=ref-doc]
+include::{app-starters-root}/testing/spring-cloud-starter-stream-sink-throughput/README.adoc[tags=ref-doc]
 
 [[spring-cloud-stream-modules-websocket-sink]]
-include::{repo-root}/websocket/spring-cloud-starter-stream-sink-websocket/README.adoc[tags=ref-doc]
+include::{app-starters-root}/websocket/spring-cloud-starter-stream-sink-websocket/README.adoc[tags=ref-doc]
 
 :leveloffset: -2

--- a/spring-cloud-stream-app-starters-docs/src/main/asciidoc/sources.adoc
+++ b/spring-cloud-stream-app-starters-docs/src/main/asciidoc/sources.adoc
@@ -2,45 +2,46 @@
 == Sources
 
 :leveloffset: +2
+:app-starters-root:  https://raw.githubusercontent.com/spring-cloud/spring-cloud-stream-app-starters/master
 
 [[spring-cloud-stream-modules-file-source]]
-include::{repo-root}/file/spring-cloud-starter-stream-source-file/README.adoc[tags=ref-doc]
+include::{app-starters-root}/file/spring-cloud-starter-stream-source-file/README.adoc[tags=ref-doc]
 
 [[spring-cloud-stream-modules-ftp-source]]
-include::{repo-root}/ftp/spring-cloud-starter-stream-source-ftp/README.adoc[tags=ref-doc]
+include::{app-starters-root}/ftp/spring-cloud-starter-stream-source-ftp/README.adoc[tags=ref-doc]
 
 [[spring-cloud-stream-modules-http-source]]
-include::{repo-root}/http/spring-cloud-starter-stream-source-http/README.adoc[tags=ref-doc]
+include::{app-starters-root}/http/spring-cloud-starter-stream-source-http/README.adoc[tags=ref-doc]
 
 [[spring-cloud-stream-modules-jdbc-source]]
-include::{repo-root}/jdbc/spring-cloud-starter-stream-source-jdbc/README.adoc[tags=ref-doc]
+include::{app-starters-root}/jdbc/spring-cloud-starter-stream-source-jdbc/README.adoc[tags=ref-doc]
 
 [[spring-cloud-stream-modules-jms-source]]
-include::{repo-root}/jms/spring-cloud-starter-stream-source-jms/README.adoc[tags=ref-doc]
+include::{app-starters-root}/jms/spring-cloud-starter-stream-source-jms/README.adoc[tags=ref-doc]
 
 [[spring-cloud-stream-modules-load-generator-source]]
-include::{repo-root}/testing/spring-cloud-starter-stream-source-load-generator/README.adoc[tags=ref-doc]
+include::{app-starters-root}/testing/spring-cloud-starter-stream-source-load-generator/README.adoc[tags=ref-doc]
 
 [[spring-cloud-stream-modules-rabbit-source]]
-include::{repo-root}/rabbit/spring-cloud-starter-stream-source-rabbit/README.adoc[tags=ref-doc]
+include::{app-starters-root}/rabbit/spring-cloud-starter-stream-source-rabbit/README.adoc[tags=ref-doc]
 
 [[spring-cloud-stream-modules-sftp-source]]
-include::{repo-root}/sftp/spring-cloud-starter-stream-source-sftp/README.adoc[tags=ref-doc]
+include::{app-starters-root}/sftp/spring-cloud-starter-stream-source-sftp/README.adoc[tags=ref-doc]
 
 [[spring-clound-stream-modules-syslog-source]]
-include::{repo-root}/syslog/spring-cloud-starter-stream-source-syslog/README.adoc[tags=ref-doc]
+include::{app-starters-root}/syslog/spring-cloud-starter-stream-source-syslog/README.adoc[tags=ref-doc]
 
 [[spring-clound-stream-modules-tcp-source]]
-include::{repo-root}/tcp/spring-cloud-starter-stream-source-tcp/README.adoc[tags=ref-doc]
+include::{app-starters-root}/tcp/spring-cloud-starter-stream-source-tcp/README.adoc[tags=ref-doc]
 
 [[spring-cloud-stream-modules-time-source]]
-include::{repo-root}/time/spring-cloud-starter-stream-source-time/README.adoc[tags=ref-doc]
+include::{app-starters-root}/time/spring-cloud-starter-stream-source-time/README.adoc[tags=ref-doc]
 
 [[spring-cloud-stream-modules-trigger-source]]
-include::{repo-root}/trigger/spring-cloud-starter-stream-source-trigger/README.adoc[tags=ref-doc]
+include::{app-starters-root}/trigger/spring-cloud-starter-stream-source-trigger/README.adoc[tags=ref-doc]
 
 [[spring-cloud-stream-modules-twitterstream-source]]
-include::{repo-root}/twitter/spring-cloud-starter-stream-source-twitterstream/README.adoc[tags=ref-doc]
+include::{app-starters-root}/twitter/spring-cloud-starter-stream-source-twitterstream/README.adoc[tags=ref-doc]
 
 :leveloffset: -2
 


### PR DESCRIPTION
Other projects that need to use the sources, sinks, processor adocs don't have the repo-root property and thus can't add the modules section to their docs.

Renamed repo-root to app-starters-root and initialized the property in the source, sink, and processor adocs.

you can see how it looked to the deployer docs by clicking this link: https://github.com/spring-cloud/spring-cloud-stream-app-starters/blob/master/spring-cloud-stream-app-starters-docs/src/main/asciidoc/sources.adoc

Thoughts?
