### PR TITLE
Remove duplicate SCS and SI-test dependencies from starters

### DIFF
--- a/app-starters-common/app-starters-annotation-common/pom.xml
+++ b/app-starters-common/app-starters-annotation-common/pom.xml
@@ -10,19 +10,4 @@
 	<artifactId>app-starters-annotation-common</artifactId>
 	<name>app-starters-annotation-common</name>
 
-	<dependencies>
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream</artifactId>
-			<version>${spring-cloud-stream.version}</version>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.integration</groupId>
-			<artifactId>spring-integration-java-dsl</artifactId>
-			<version>${spring-integration-java-dsl.version}</version>
-		</dependency>
-
-	</dependencies>
-
 </project>

--- a/app-starters-common/app-starters-file-common/pom.xml
+++ b/app-starters-common/app-starters-file-common/pom.xml
@@ -12,23 +12,10 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream</artifactId>
-			<version>${spring-cloud-stream.version}</version>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.integration</groupId>
-			<artifactId>spring-integration-java-dsl</artifactId>
-			<version>1.1.2.RELEASE</version>
-		</dependency>
-
-		<dependency>
 			<groupId>org.springframework.integration</groupId>
 			<artifactId>spring-integration-file</artifactId>
 			<optional>true</optional>
 		</dependency>
-
 	</dependencies>
 
 </project>

--- a/app-starters-common/app-starters-ftp-common/pom.xml
+++ b/app-starters-common/app-starters-ftp-common/pom.xml
@@ -12,29 +12,15 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream</artifactId>
-			<version>${spring-cloud-stream.version}</version>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.integration</groupId>
-			<artifactId>spring-integration-java-dsl</artifactId>
-			<version>1.1.2.RELEASE</version>
-		</dependency>
-
-		<dependency>
 			<groupId>org.springframework.integration</groupId>
 			<artifactId>spring-integration-ftp</artifactId>
 			<optional>true</optional>
 		</dependency>
-
 		<dependency>
 			<groupId>org.springframework.cloud.stream.app</groupId>
 			<artifactId>app-starters-file-common</artifactId>
 			<version>1.0.0.BUILD-SNAPSHOT</version>
 		</dependency>
-
 	</dependencies>
 
 </project>

--- a/app-starters-common/app-starters-metrics-common/pom.xml
+++ b/app-starters-common/app-starters-metrics-common/pom.xml
@@ -10,19 +10,4 @@
 	<artifactId>app-starters-metrics-common</artifactId>
 	<name>app-starters-metrics-common</name>
 
-	<dependencies>
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream</artifactId>
-			<version>${spring-cloud-stream.version}</version>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.integration</groupId>
-			<artifactId>spring-integration-java-dsl</artifactId>
-			<version>1.1.2.RELEASE</version>
-		</dependency>
-
-	</dependencies>
-
 </project>

--- a/app-starters-common/app-starters-script-common/pom.xml
+++ b/app-starters-common/app-starters-script-common/pom.xml
@@ -12,23 +12,10 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream</artifactId>
-			<version>${spring-cloud-stream.version}</version>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.integration</groupId>
-			<artifactId>spring-integration-java-dsl</artifactId>
-			<version>1.1.2.RELEASE</version>
-		</dependency>
-
-		<dependency>
 			<groupId>org.springframework.integration</groupId>
 			<artifactId>spring-integration-groovy</artifactId>
 			<optional>true</optional>
 		</dependency>
-
 	</dependencies>
 
 </project>

--- a/app-starters-common/app-starters-sftp-common/pom.xml
+++ b/app-starters-common/app-starters-sftp-common/pom.xml
@@ -12,29 +12,15 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream</artifactId>
-			<version>${spring-cloud-stream.version}</version>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.integration</groupId>
-			<artifactId>spring-integration-java-dsl</artifactId>
-			<version>1.1.2.RELEASE</version>
-		</dependency>
-
-		<dependency>
 			<groupId>org.springframework.integration</groupId>
 			<artifactId>spring-integration-sftp</artifactId>
 			<optional>true</optional>
 		</dependency>
-
 		<dependency>
 			<groupId>org.springframework.cloud.stream.app</groupId>
 			<artifactId>app-starters-file-common</artifactId>
 			<version>1.0.0.BUILD-SNAPSHOT</version>
 		</dependency>
-
 	</dependencies>
 
 </project>

--- a/app-starters-common/app-starters-tcp-common/pom.xml
+++ b/app-starters-common/app-starters-tcp-common/pom.xml
@@ -12,23 +12,10 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream</artifactId>
-			<version>${spring-cloud-stream.version}</version>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.integration</groupId>
-			<artifactId>spring-integration-java-dsl</artifactId>
-			<version>1.1.2.RELEASE</version>
-		</dependency>
-
-		<dependency>
 			<groupId>org.springframework.integration</groupId>
 			<artifactId>spring-integration-ip</artifactId>
 			<optional>true</optional>
 		</dependency>
-
 	</dependencies>
 
 </project>

--- a/app-starters-common/app-starters-time-common/pom.xml
+++ b/app-starters-common/app-starters-time-common/pom.xml
@@ -10,19 +10,4 @@
 	<artifactId>app-starters-time-common</artifactId>
 	<name>app-starters-time-common</name>
 
-	<dependencies>
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream</artifactId>
-			<version>${spring-cloud-stream.version}</version>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.integration</groupId>
-			<artifactId>spring-integration-java-dsl</artifactId>
-			<version>1.1.2.RELEASE</version>
-		</dependency>
-
-	</dependencies>
-
 </project>

--- a/app-starters-common/app-starters-trigger-common/pom.xml
+++ b/app-starters-common/app-starters-trigger-common/pom.xml
@@ -11,19 +11,4 @@
 	<packaging>jar</packaging>
 	<name>app-starters-trigger-common</name>
 
-	<dependencies>
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream</artifactId>
-			<version>${spring-cloud-stream.version}</version>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.integration</groupId>
-			<artifactId>spring-integration-java-dsl</artifactId>
-			<version>1.1.2.RELEASE</version>
-		</dependency>
-
-	</dependencies>
-
 </project>

--- a/app-starters-common/app-starters-twitter-common/pom.xml
+++ b/app-starters-common/app-starters-twitter-common/pom.xml
@@ -12,23 +12,10 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream</artifactId>
-			<version>${spring-cloud-stream.version}</version>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.integration</groupId>
-			<artifactId>spring-integration-java-dsl</artifactId>
-			<version>1.1.2.RELEASE</version>
-		</dependency>
-
-		<dependency>
 			<groupId>org.springframework.integration</groupId>
 			<artifactId>spring-integration-ip</artifactId>
 			<optional>true</optional>
 		</dependency>
-
 	</dependencies>
 
 </project>

--- a/app-starters-common/pom.xml
+++ b/app-starters-common/pom.xml
@@ -24,4 +24,12 @@
 		<module>app-starters-twitter-common</module>
 	</modules>
 
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.integration</groupId>
+			<artifactId>spring-integration-java-dsl</artifactId>
+			<version>${spring-integration-java-dsl.version}</version>
+		</dependency>
+	</dependencies>
+
 </project>

--- a/cassandra/spring-cloud-starter-stream-sink-cassandra/pom.xml
+++ b/cassandra/spring-cloud-starter-stream-sink-cassandra/pom.xml
@@ -26,17 +26,5 @@
 			<groupId>org.cassandraunit</groupId>
 			<artifactId>cassandra-unit-spring</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream-test-support</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.integration</groupId>
-			<artifactId>spring-integration-test</artifactId>
-		</dependency>
 	</dependencies>
 </project>

--- a/cloudfoundry/spring-cloud-starter-stream-source-loggregator/pom.xml
+++ b/cloudfoundry/spring-cloud-starter-stream-source-loggregator/pom.xml
@@ -15,23 +15,8 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream</artifactId>
-		</dependency>
-
-		<dependency>
 			<groupId>org.cloudfoundry</groupId>
 			<artifactId>cloudfoundry-client-lib</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream-test-support</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.integration</groupId>
-			<artifactId>spring-integration-test</artifactId>
 		</dependency>
 	</dependencies>
 </project>

--- a/file/spring-cloud-starter-stream-sink-file/pom.xml
+++ b/file/spring-cloud-starter-stream-sink-file/pom.xml
@@ -18,17 +18,5 @@
 			<groupId>org.springframework.integration</groupId>
 			<artifactId>spring-integration-file</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream-test-support</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.integration</groupId>
-			<artifactId>spring-integration-test</artifactId>
-		</dependency>
 	</dependencies>
 </project>

--- a/file/spring-cloud-starter-stream-source-file/pom.xml
+++ b/file/spring-cloud-starter-stream-source-file/pom.xml
@@ -30,19 +30,5 @@
 			<groupId>org.springframework.cloud.stream.app</groupId>
 			<artifactId>app-starters-trigger-common</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream-test-support</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.integration</groupId>
-			<artifactId>spring-integration-test</artifactId>
-		</dependency>
 	</dependencies>
 </project>

--- a/ftp/spring-cloud-starter-stream-sink-ftp/pom.xml
+++ b/ftp/spring-cloud-starter-stream-sink-ftp/pom.xml
@@ -18,41 +18,17 @@
 			<groupId>org.springframework.integration</groupId>
 			<artifactId>spring-integration-ftp</artifactId>
 		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream</artifactId>
-		</dependency>
-
 		<dependency>
 			<groupId>org.springframework.cloud.stream.app</groupId>
 			<artifactId>app-starters-ftp-common</artifactId>
 		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream-test-support</artifactId>
-		</dependency>
-
 		<dependency>
 			<groupId>org.springframework.cloud.stream.app</groupId>
 			<artifactId>app-starters-test-support</artifactId>
 		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream-test-support-internal</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.integration</groupId>
-			<artifactId>spring-integration-test</artifactId>
-		</dependency>
-
 		<dependency>
 			<groupId>org.apache.ftpserver</groupId>
 			<artifactId>ftpserver-core</artifactId>
 		</dependency>
-
 	</dependencies>
 </project>

--- a/ftp/spring-cloud-starter-stream-source-ftp/pom.xml
+++ b/ftp/spring-cloud-starter-stream-source-ftp/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>spring-cloud-starter-stream-source-ftp</artifactId>
@@ -18,12 +19,10 @@
 			<groupId>org.springframework.integration</groupId>
 			<artifactId>spring-integration-ftp</artifactId>
 		</dependency>
-
 		<dependency>
 			<groupId>org.springframework.integration</groupId>
 			<artifactId>spring-integration-java-dsl</artifactId>
 		</dependency>
-
 		<dependency>
 			<groupId>org.springframework.cloud.stream.app</groupId>
 			<artifactId>app-starters-ftp-common</artifactId>
@@ -33,33 +32,12 @@
 			<artifactId>app-starters-trigger-common</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream-test-support</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream-test-support-internal</artifactId>
-		</dependency>
-
-		<dependency>
 			<groupId>org.springframework.cloud.stream.app</groupId>
 			<artifactId>app-starters-test-support</artifactId>
 		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.integration</groupId>
-			<artifactId>spring-integration-test</artifactId>
-		</dependency>
-
 		<dependency>
 			<groupId>org.apache.ftpserver</groupId>
 			<artifactId>ftpserver-core</artifactId>
 		</dependency>
-
 	</dependencies>
 </project>

--- a/gemfire/spring-cloud-starter-stream-sink-gemfire/pom.xml
+++ b/gemfire/spring-cloud-starter-stream-sink-gemfire/pom.xml
@@ -32,14 +32,6 @@
             <artifactId>sshd-core</artifactId>
         </dependency>
 		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream-test-support</artifactId>
-		</dependency>
-		<dependency>
 			<groupId>org.springframework.cloud.stream.app</groupId>
 			<artifactId>app-starters-test-support</artifactId>
 		</dependency>

--- a/gemfire/spring-cloud-starter-stream-source-gemfire-cq/pom.xml
+++ b/gemfire/spring-cloud-starter-stream-source-gemfire-cq/pom.xml
@@ -20,24 +20,9 @@
             <artifactId>spring-integration-gemfire</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.springframework.integration</groupId>
-            <artifactId>spring-integration-test</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.apache.sshd</groupId>
             <artifactId>sshd-core</artifactId>
         </dependency>
-
-        <dependency>
-            <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-stream</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-stream-test-support</artifactId>
-        </dependency>
-
         <dependency>
             <groupId>org.springframework.cloud.stream.app</groupId>
             <artifactId>app-starters-test-support</artifactId>
@@ -46,6 +31,5 @@
             <groupId>org.springframework.integration</groupId>
             <artifactId>spring-integration-java-dsl</artifactId>
         </dependency>
-
     </dependencies>
 </project>

--- a/gemfire/spring-cloud-starter-stream-source-gemfire/pom.xml
+++ b/gemfire/spring-cloud-starter-stream-source-gemfire/pom.xml
@@ -20,24 +20,9 @@
             <artifactId>spring-integration-gemfire</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.springframework.integration</groupId>
-            <artifactId>spring-integration-test</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.apache.sshd</groupId>
             <artifactId>sshd-core</artifactId>
         </dependency>
-
-        <dependency>
-            <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-stream</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-stream-test-support</artifactId>
-        </dependency>
-
         <dependency>
             <groupId>org.springframework.cloud.stream.app</groupId>
             <artifactId>app-starters-test-support</artifactId>
@@ -46,6 +31,5 @@
             <groupId>org.springframework.integration</groupId>
             <artifactId>spring-integration-java-dsl</artifactId>
         </dependency>
-
     </dependencies>
 </project>

--- a/gpfdist/spring-cloud-starter-stream-sink-gpfdist/pom.xml
+++ b/gpfdist/spring-cloud-starter-stream-sink-gpfdist/pom.xml
@@ -45,22 +45,6 @@
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-hadoop-util</artifactId>
 		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream-test-support</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.integration</groupId>
-			<artifactId>spring-integration-test</artifactId>
-		</dependency>
-
 		<dependency>
 			<groupId>org.springframework.cloud.stream.app</groupId>
 			<artifactId>app-starters-test-support</artifactId>

--- a/hdfs/spring-cloud-starter-stream-sink-hdfs-dataset/pom.xml
+++ b/hdfs/spring-cloud-starter-stream-sink-hdfs-dataset/pom.xml
@@ -20,27 +20,6 @@
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-hadoop-store</artifactId>
 		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream-test-support</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.integration</groupId>
-			<artifactId>spring-integration-test</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream-test-support-internal</artifactId>
-		</dependency>
-
 		<dependency>
 			<groupId>org.xerial.snappy</groupId>
 			<artifactId>snappy-java</artifactId>

--- a/hdfs/spring-cloud-starter-stream-sink-hdfs/pom.xml
+++ b/hdfs/spring-cloud-starter-stream-sink-hdfs/pom.xml
@@ -20,25 +20,5 @@
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-hadoop-store</artifactId>
 		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream-test-support</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.integration</groupId>
-			<artifactId>spring-integration-test</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream-test-support-internal</artifactId>
-		</dependency>
 	</dependencies>
 </project>

--- a/http/spring-cloud-starter-stream-source-http/pom.xml
+++ b/http/spring-cloud-starter-stream-source-http/pom.xml
@@ -15,23 +15,8 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream</artifactId>
-		</dependency>
-
-		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream-test-support</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.integration</groupId>
-			<artifactId>spring-integration-test</artifactId>
 		</dependency>
 	</dependencies>
 </project>

--- a/jdbc/spring-cloud-starter-stream-sink-jdbc/pom.xml
+++ b/jdbc/spring-cloud-starter-stream-sink-jdbc/pom.xml
@@ -21,17 +21,5 @@
 			<groupId>org.hsqldb</groupId>
 			<artifactId>hsqldb</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream-test-support</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.integration</groupId>
-			<artifactId>spring-integration-test</artifactId>
-		</dependency>
 	</dependencies>
 </project>

--- a/jdbc/spring-cloud-starter-stream-source-jdbc/pom.xml
+++ b/jdbc/spring-cloud-starter-stream-source-jdbc/pom.xml
@@ -13,7 +13,6 @@
 	</parent>
 
 	<dependencies>
-
 		<dependency>
 			<groupId>org.springframework.integration</groupId>
 			<artifactId>spring-integration-java-dsl</artifactId>
@@ -27,21 +26,8 @@
 			<artifactId>hsqldb</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream-test-support</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.integration</groupId>
-			<artifactId>spring-integration-test</artifactId>
-		</dependency>
-		<dependency>
 			<groupId>org.springframework.cloud.stream.app</groupId>
 			<artifactId>app-starters-trigger-common</artifactId>
 		</dependency>
-
 	</dependencies>
 </project>

--- a/jms/spring-cloud-starter-stream-source-jms/pom.xml
+++ b/jms/spring-cloud-starter-stream-source-jms/pom.xml
@@ -22,36 +22,14 @@
 			<groupId>org.springframework.integration</groupId>
 			<artifactId>spring-integration-java-dsl</artifactId>
 		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream</artifactId>
-		</dependency>
 		<dependency>
 			<groupId>javax.jms</groupId>
 			<artifactId>jms-api</artifactId>
 		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream-test-support</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream-test-support-internal</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.integration</groupId>
-			<artifactId>spring-integration-test</artifactId>
-		</dependency>
-
 		<dependency>
 			<groupId>org.apache.activemq</groupId>
 			<artifactId>activemq-broker</artifactId>
 			<scope>test</scope>
 		</dependency>
-
 	</dependencies>
 </project>

--- a/log/spring-cloud-starter-stream-sink-log/pom.xml
+++ b/log/spring-cloud-starter-stream-sink-log/pom.xml
@@ -11,22 +11,4 @@
 		<version>1.0.0.BUILD-SNAPSHOT</version>
 	</parent>
 
-	<dependencies>
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream-test-support</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.integration</groupId>
-			<artifactId>spring-integration-test</artifactId>
-		</dependency>
-	</dependencies>
-
-
 </project>

--- a/metrics/spring-cloud-starter-stream-sink-aggregate-counter/pom.xml
+++ b/metrics/spring-cloud-starter-stream-sink-aggregate-counter/pom.xml
@@ -13,44 +13,21 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream</artifactId>
-		</dependency>
-
-		<dependency>
 			<groupId>org.springframework.cloud.stream.app</groupId>
 			<artifactId>app-starters-metrics-common</artifactId>
 		</dependency>
-
 		<dependency>
 			<groupId>org.springframework.cloud.stream.app</groupId>
 			<artifactId>app-starters-common-analytics</artifactId>
 		</dependency>
-
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-redis</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream-test-support</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream-test-support-internal</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.integration</groupId>
-			<artifactId>spring-integration-test</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud.stream.app</groupId>
 			<artifactId>app-starters-time-common</artifactId>
 		</dependency>
 	</dependencies>
-
 
 </project>

--- a/metrics/spring-cloud-starter-stream-sink-counter/pom.xml
+++ b/metrics/spring-cloud-starter-stream-sink-counter/pom.xml
@@ -13,35 +13,13 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream</artifactId>
-		</dependency>
-
-		<dependency>
 			<groupId>org.springframework.cloud.stream.app</groupId>
 			<artifactId>app-starters-metrics-common</artifactId>
 		</dependency>
-
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-redis</artifactId>
 		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream-test-support</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream-test-support-internal</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.integration</groupId>
-			<artifactId>spring-integration-test</artifactId>
-		</dependency>
 	</dependencies>
-
 
 </project>

--- a/metrics/spring-cloud-starter-stream-sink-field-value-counter/pom.xml
+++ b/metrics/spring-cloud-starter-stream-sink-field-value-counter/pom.xml
@@ -13,40 +13,17 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream</artifactId>
-		</dependency>
-
-		<dependency>
 			<groupId>org.springframework.cloud.stream.app</groupId>
 			<artifactId>app-starters-metrics-common</artifactId>
 		</dependency>
-
 		<dependency>
 			<groupId>org.springframework.cloud.stream.app</groupId>
 			<artifactId>app-starters-common-analytics</artifactId>
 		</dependency>
-
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-redis</artifactId>
 		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream-test-support</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream-test-support-internal</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.integration</groupId>
-			<artifactId>spring-integration-test</artifactId>
-		</dependency>
 	</dependencies>
-
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1,19 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
-  <parent>
-    <groupId>org.springframework.cloud</groupId>
-    <artifactId>spring-cloud-build</artifactId>
-    <version>1.1.0.RC1</version>
-    <relativePath />
-  </parent>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.cloud</groupId>
+		<artifactId>spring-cloud-build</artifactId>
+		<version>1.1.0.RC1</version>
+		<relativePath/>
+	</parent>
 
-  <groupId>org.springframework.cloud.stream.app</groupId>
-  <artifactId>spring-cloud-stream-app-starters</artifactId>
-  <version>1.0.0.BUILD-SNAPSHOT</version>
-  <packaging>pom</packaging>
+	<groupId>org.springframework.cloud.stream.app</groupId>
+	<artifactId>spring-cloud-stream-app-starters</artifactId>
+	<version>1.0.0.BUILD-SNAPSHOT</version>
+	<packaging>pom</packaging>
 
 	<dependencies>
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-stream</artifactId>
+		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-configuration-processor</artifactId>
@@ -27,151 +32,166 @@
 			<groupId>org.springframework.integration</groupId>
 			<artifactId>spring-integration-xml</artifactId>
 		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-stream-test-support</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-stream-test-support-internal</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.integration</groupId>
+			<artifactId>spring-integration-test</artifactId>
+		</dependency>
+
 	</dependencies>
 
-  <properties>
-    <scs-app-maven-plugin.version>1.0.0.BUILD-SNAPSHOT</scs-app-maven-plugin.version>
-    <java.version>1.7</java.version>
-    <spring-cloud-stream.version>1.0.0.RC3</spring-cloud-stream.version>
-    <spring-integration.version>4.2.5.RELEASE</spring-integration.version>
-    <spring-integration-java-dsl.version>1.1.2.RELEASE</spring-integration-java-dsl.version>
-  </properties>
+	<properties>
+		<scs-app-maven-plugin.version>1.0.0.BUILD-SNAPSHOT</scs-app-maven-plugin.version>
+		<java.version>1.7</java.version>
+		<spring-cloud-stream.version>1.0.0.RC3</spring-cloud-stream.version>
+		<spring-integration.version>4.2.5.RELEASE</spring-integration.version>
+		<spring-integration-java-dsl.version>1.1.2.RELEASE</spring-integration-java-dsl.version>
+	</properties>
 
-  <modules>
-    <module>spring-cloud-stream-app-dependencies</module>
-    <module>spring-cloud-stream-app-generator</module>
-    <module>spring-cloud-stream-app-starters-docs</module>
-    <module>spring-cloud-stream-app-descriptor</module>
-    <module>app-starters-common</module>
-    <module>app-starters-common-analytics</module>
-    <module>app-starters-test-support</module>
-    <module>cassandra</module>
-    <module>cloudfoundry</module>
-    <module>file</module>
-    <module>ftp</module>
-    <module>gemfire</module>
-    <module>gpfdist</module>
-    <module>hdfs</module>
-    <module>http</module>
-    <module>jdbc</module>
-    <module>jms</module>
-    <module>log</module>
-    <module>metrics</module>
-    <module>processor</module>
-    <module>rabbit</module>
-    <module>redis</module>
-    <module>router</module>
-    <module>sftp</module>
-    <module>syslog</module>
-    <module>tcp</module>
-    <module>testing</module>
-    <module>time</module>
-    <module>trigger</module>
-    <module>twitter</module>
-    <module>websocket</module>
-  </modules>
+	<modules>
+		<module>spring-cloud-stream-app-dependencies</module>
+		<module>spring-cloud-stream-app-generator</module>
+		<module>spring-cloud-stream-app-starters-docs</module>
+		<module>spring-cloud-stream-app-descriptor</module>
+		<module>app-starters-common</module>
+		<module>app-starters-common-analytics</module>
+		<module>app-starters-test-support</module>
+		<module>cassandra</module>
+		<module>cloudfoundry</module>
+		<module>file</module>
+		<module>ftp</module>
+		<module>gemfire</module>
+		<module>gpfdist</module>
+		<module>hdfs</module>
+		<module>http</module>
+		<module>jdbc</module>
+		<module>jms</module>
+		<module>log</module>
+		<module>metrics</module>
+		<module>processor</module>
+		<module>rabbit</module>
+		<module>redis</module>
+		<module>router</module>
+		<module>sftp</module>
+		<module>syslog</module>
+		<module>tcp</module>
+		<module>testing</module>
+		<module>time</module>
+		<module>trigger</module>
+		<module>twitter</module>
+		<module>websocket</module>
+	</modules>
 
-  <scm>
-    <connection>scm:git:git://github.com/spring-cloud/spring-cloud-stream-app-starters.git</connection>
-    <developerConnection>scm:git:ssh://git@github.com/spring-cloud/spring-cloud-stream-app-starters.git</developerConnection>
-    <url>https://github.com/spring-cloud/spring-cloud-stream-app-starters</url>
-  </scm>
+	<scm>
+		<connection>scm:git:git://github.com/spring-cloud/spring-cloud-stream-app-starters.git</connection>
+		<developerConnection>scm:git:ssh://git@github.com/spring-cloud/spring-cloud-stream-app-starters.git
+		</developerConnection>
+		<url>https://github.com/spring-cloud/spring-cloud-stream-app-starters</url>
+	</scm>
 
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>org.springframework.cloud.stream.app</groupId>
-        <artifactId>spring-cloud-stream-app-dependencies</artifactId>
-        <version>1.0.0.BUILD-SNAPSHOT</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.springframework.cloud.stream.app</groupId>
+				<artifactId>spring-cloud-stream-app-dependencies</artifactId>
+				<version>1.0.0.BUILD-SNAPSHOT</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
 
-  <build>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <artifactId>maven-javadoc-plugin</artifactId>
-          <configuration>
-            <quiet>true</quiet>
-          </configuration>
-        </plugin>
-        <plugin>
-          <artifactId>maven-surefire-plugin</artifactId>
-          <configuration>
-            <redirectTestOutputToFile>true</redirectTestOutputToFile>
-          </configuration>
-        </plugin>
-      </plugins>
-    </pluginManagement>
-  </build>
+	<build>
+		<pluginManagement>
+			<plugins>
+				<plugin>
+					<artifactId>maven-javadoc-plugin</artifactId>
+					<configuration>
+						<quiet>true</quiet>
+					</configuration>
+				</plugin>
+				<plugin>
+					<artifactId>maven-surefire-plugin</artifactId>
+					<configuration>
+						<redirectTestOutputToFile>true</redirectTestOutputToFile>
+					</configuration>
+				</plugin>
+			</plugins>
+		</pluginManagement>
+	</build>
 
-  <profiles>
-    <profile>
-      <id>spring</id>
-      <repositories>
-        <repository>
-          <snapshots>
-            <enabled>true</enabled>
-          </snapshots>
-          <id>spring-snapshots</id>
-          <name>Spring Snapshots</name>
-          <url>http://repo.spring.io/libs-snapshot-local</url>
-        </repository>
-        <repository>
-          <snapshots>
-            <enabled>false</enabled>
-          </snapshots>
-          <id>spring-milestones</id>
-          <name>Spring Milestones</name>
-          <url>http://repo.spring.io/libs-milestone-local</url>
-        </repository>
-        <repository>
-          <snapshots>
-            <enabled>false</enabled>
-          </snapshots>
-          <id>spring-releases</id>
-          <name>Spring Releases</name>
-          <url>http://repo.spring.io/release</url>
-        </repository>
-        <repository>
-          <snapshots>
-            <enabled>false</enabled>
-          </snapshots>
-          <id>spring-libs-release</id>
-          <name>Spring Libs Release</name>
-          <url>http://repo.spring.io/libs-release</url>
-        </repository>
-        <repository>
-          <snapshots>
-            <enabled>false</enabled>
-          </snapshots>
-          <id>spring-milestone-release</id>
-          <name>Spring Milestone Release</name>
-          <url>http://repo.spring.io/libs-milestone</url>
-        </repository>
-      </repositories>
-      <pluginRepositories>
-        <pluginRepository>
-          <snapshots>
-            <enabled>true</enabled>
-          </snapshots>
-          <id>spring-snapshots</id>
-          <name>Spring Snapshots</name>
-          <url>http://repo.spring.io/libs-snapshot-local</url>
-        </pluginRepository>
-        <pluginRepository>
-          <snapshots>
-            <enabled>false</enabled>
-          </snapshots>
-          <id>spring-milestones</id>
-          <name>Spring Milestones</name>
-          <url>http://repo.spring.io/libs-milestone-local</url>
-        </pluginRepository>
-      </pluginRepositories>
-    </profile>
-  </profiles>
+	<profiles>
+		<profile>
+			<id>spring</id>
+			<repositories>
+				<repository>
+					<snapshots>
+						<enabled>true</enabled>
+					</snapshots>
+					<id>spring-snapshots</id>
+					<name>Spring Snapshots</name>
+					<url>http://repo.spring.io/libs-snapshot-local</url>
+				</repository>
+				<repository>
+					<snapshots>
+						<enabled>false</enabled>
+					</snapshots>
+					<id>spring-milestones</id>
+					<name>Spring Milestones</name>
+					<url>http://repo.spring.io/libs-milestone-local</url>
+				</repository>
+				<repository>
+					<snapshots>
+						<enabled>false</enabled>
+					</snapshots>
+					<id>spring-releases</id>
+					<name>Spring Releases</name>
+					<url>http://repo.spring.io/release</url>
+				</repository>
+				<repository>
+					<snapshots>
+						<enabled>false</enabled>
+					</snapshots>
+					<id>spring-libs-release</id>
+					<name>Spring Libs Release</name>
+					<url>http://repo.spring.io/libs-release</url>
+				</repository>
+				<repository>
+					<snapshots>
+						<enabled>false</enabled>
+					</snapshots>
+					<id>spring-milestone-release</id>
+					<name>Spring Milestone Release</name>
+					<url>http://repo.spring.io/libs-milestone</url>
+				</repository>
+			</repositories>
+			<pluginRepositories>
+				<pluginRepository>
+					<snapshots>
+						<enabled>true</enabled>
+					</snapshots>
+					<id>spring-snapshots</id>
+					<name>Spring Snapshots</name>
+					<url>http://repo.spring.io/libs-snapshot-local</url>
+				</pluginRepository>
+				<pluginRepository>
+					<snapshots>
+						<enabled>false</enabled>
+					</snapshots>
+					<id>spring-milestones</id>
+					<name>Spring Milestones</name>
+					<url>http://repo.spring.io/libs-milestone-local</url>
+				</pluginRepository>
+			</pluginRepositories>
+		</profile>
+	</profiles>
 
 </project>

--- a/processor/spring-cloud-starter-stream-processor-bridge/pom.xml
+++ b/processor/spring-cloud-starter-stream-processor-bridge/pom.xml
@@ -13,21 +13,4 @@
 		<version>1.0.0.BUILD-SNAPSHOT</version>
 	</parent>
 
-	<dependencies>
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream-test-support</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.integration</groupId>
-			<artifactId>spring-integration-test</artifactId>
-		</dependency>
-
-	</dependencies>
 </project>

--- a/processor/spring-cloud-starter-stream-processor-filter/pom.xml
+++ b/processor/spring-cloud-starter-stream-processor-filter/pom.xml
@@ -13,21 +13,4 @@
 		<version>1.0.0.BUILD-SNAPSHOT</version>
 	</parent>
 
-	<dependencies>
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream-test-support</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.integration</groupId>
-			<artifactId>spring-integration-test</artifactId>
-		</dependency>
-
-	</dependencies>
 </project>

--- a/processor/spring-cloud-starter-stream-processor-groovy-filter/pom.xml
+++ b/processor/spring-cloud-starter-stream-processor-groovy-filter/pom.xml
@@ -18,25 +18,9 @@
 			<groupId>org.springframework.integration</groupId>
 			<artifactId>spring-integration-groovy</artifactId>
 		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream-test-support</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.integration</groupId>
-			<artifactId>spring-integration-test</artifactId>
-		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud.stream.app</groupId>
 			<artifactId>app-starters-script-common</artifactId>
 		</dependency>
-
 	</dependencies>
 </project>

--- a/processor/spring-cloud-starter-stream-processor-groovy-transform/pom.xml
+++ b/processor/spring-cloud-starter-stream-processor-groovy-transform/pom.xml
@@ -18,25 +18,9 @@
 			<groupId>org.springframework.integration</groupId>
 			<artifactId>spring-integration-groovy</artifactId>
 		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream-test-support</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.integration</groupId>
-			<artifactId>spring-integration-test</artifactId>
-		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud.stream.app</groupId>
 			<artifactId>app-starters-script-common</artifactId>
 		</dependency>
-
 	</dependencies>
 </project>

--- a/processor/spring-cloud-starter-stream-processor-httpclient/pom.xml
+++ b/processor/spring-cloud-starter-stream-processor-httpclient/pom.xml
@@ -18,22 +18,6 @@
 			<groupId>org.springframework.integration</groupId>
 			<artifactId>spring-integration-http</artifactId>
 		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream-test-support</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.integration</groupId>
-			<artifactId>spring-integration-test</artifactId>
-		</dependency>
-
 		<dependency>
 			<groupId>org.springframework.integration</groupId>
 			<artifactId>spring-integration-event</artifactId>

--- a/processor/spring-cloud-starter-stream-processor-pmml/pom.xml
+++ b/processor/spring-cloud-starter-stream-processor-pmml/pom.xml
@@ -15,29 +15,12 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream</artifactId>
+			<groupId>org.jpmml</groupId>
+			<artifactId>pmml-evaluator</artifactId>
 		</dependency>
-
 		<dependency>
 			<groupId>org.springframework.cloud.stream.app</groupId>
 			<artifactId>app-starters-test-support</artifactId>
 		</dependency>
-
-		<dependency>
-			<groupId>org.jpmml</groupId>
-			<artifactId>pmml-evaluator</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream-test-support</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.integration</groupId>
-			<artifactId>spring-integration-test</artifactId>
-		</dependency>
-
 	</dependencies>
 </project>

--- a/processor/spring-cloud-starter-stream-processor-scriptable-transform/pom.xml
+++ b/processor/spring-cloud-starter-stream-processor-scriptable-transform/pom.xml
@@ -18,36 +18,17 @@
 			<groupId>org.springframework.integration</groupId>
 			<artifactId>spring-integration-groovy</artifactId>
 		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream</artifactId>
-		</dependency>
-
 		<dependency>
 			<groupId>org.jruby</groupId>
 			<artifactId>jruby-complete</artifactId>
 		</dependency>
-
 		<dependency>
 			<groupId>org.python</groupId>
 			<artifactId>jython-standalone</artifactId>
 		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream-test-support</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.integration</groupId>
-			<artifactId>spring-integration-test</artifactId>
-		</dependency>
-
 		<dependency>
 			<groupId>org.springframework.cloud.stream.app</groupId>
 			<artifactId>app-starters-script-common</artifactId>
 		</dependency>
-
 	</dependencies>
 </project>

--- a/processor/spring-cloud-starter-stream-processor-splitter/pom.xml
+++ b/processor/spring-cloud-starter-stream-processor-splitter/pom.xml
@@ -18,21 +18,5 @@
 			<groupId>org.springframework.integration</groupId>
 			<artifactId>spring-integration-file</artifactId>
 		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream-test-support</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.integration</groupId>
-			<artifactId>spring-integration-test</artifactId>
-		</dependency>
-
 	</dependencies>
 </project>

--- a/processor/spring-cloud-starter-stream-processor-transform/pom.xml
+++ b/processor/spring-cloud-starter-stream-processor-transform/pom.xml
@@ -13,21 +13,4 @@
 		<version>1.0.0.BUILD-SNAPSHOT</version>
 	</parent>
 
-	<dependencies>
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream-test-support</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.integration</groupId>
-			<artifactId>spring-integration-test</artifactId>
-		</dependency>
-
-	</dependencies>
 </project>

--- a/rabbit/spring-cloud-starter-stream-sink-rabbit/pom.xml
+++ b/rabbit/spring-cloud-starter-stream-sink-rabbit/pom.xml
@@ -18,25 +18,5 @@
 			<groupId>org.springframework.integration</groupId>
 			<artifactId>spring-integration-amqp</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream-test-support</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream-test-support-internal</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.integration</groupId>
-			<artifactId>spring-integration-test</artifactId>
-		</dependency>
-
 	</dependencies>
 </project>

--- a/rabbit/spring-cloud-starter-stream-source-rabbit/pom.xml
+++ b/rabbit/spring-cloud-starter-stream-source-rabbit/pom.xml
@@ -22,24 +22,5 @@
 			<groupId>org.springframework.integration</groupId>
 			<artifactId>spring-integration-java-dsl</artifactId>
 		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream-test-support</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream-test-support-internal</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.integration</groupId>
-			<artifactId>spring-integration-test</artifactId>
-		</dependency>
 	</dependencies>
 </project>

--- a/redis/spring-cloud-starter-stream-sink-redis/pom.xml
+++ b/redis/spring-cloud-starter-stream-sink-redis/pom.xml
@@ -16,20 +16,8 @@
 			<artifactId>spring-boot-starter-redis</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream</artifactId>
-		</dependency>
-		<dependency>
 			<groupId>org.springframework.integration</groupId>
 			<artifactId>spring-integration-redis</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream-test-support</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream-test-support-internal</artifactId>
 		</dependency>
 	</dependencies>
 </project>

--- a/router/spring-cloud-starter-stream-sink-router/pom.xml
+++ b/router/spring-cloud-starter-stream-sink-router/pom.xml
@@ -18,22 +18,6 @@
 			<groupId>org.springframework.integration</groupId>
 			<artifactId>spring-integration-groovy</artifactId>
 		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream-test-support</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.integration</groupId>
-			<artifactId>spring-integration-test</artifactId>
-		</dependency>
-
 		<dependency>
 			<groupId>org.springframework.cloud.stream.app</groupId>
 			<artifactId>app-starters-script-common</artifactId>

--- a/sftp/spring-cloud-starter-stream-sink-sftp/pom.xml
+++ b/sftp/spring-cloud-starter-stream-sink-sftp/pom.xml
@@ -18,41 +18,17 @@
 			<groupId>org.springframework.integration</groupId>
 			<artifactId>spring-integration-sftp</artifactId>
 		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream</artifactId>
-		</dependency>
-
 		<dependency>
 			<groupId>org.springframework.cloud.stream.app</groupId>
 			<artifactId>app-starters-sftp-common</artifactId>
 		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream-test-support</artifactId>
-		</dependency>
-
 		<dependency>
 			<groupId>org.springframework.cloud.stream.app</groupId>
 			<artifactId>app-starters-test-support</artifactId>
 		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream-test-support-internal</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.integration</groupId>
-			<artifactId>spring-integration-test</artifactId>
-		</dependency>
-
 		<dependency>
 			<groupId>org.apache.sshd</groupId>
 			<artifactId>sshd-core</artifactId>
 		</dependency>
-
 	</dependencies>
 </project>

--- a/sftp/spring-cloud-starter-stream-source-sftp/pom.xml
+++ b/sftp/spring-cloud-starter-stream-source-sftp/pom.xml
@@ -18,50 +18,25 @@
 			<groupId>org.springframework.integration</groupId>
 			<artifactId>spring-integration-sftp</artifactId>
 		</dependency>
-
 		<dependency>
 			<groupId>org.springframework.integration</groupId>
 			<artifactId>spring-integration-java-dsl</artifactId>
 		</dependency>
-
 		<dependency>
 			<groupId>org.springframework.cloud.stream.app</groupId>
 			<artifactId>app-starters-sftp-common</artifactId>
 		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream-test-support</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream-test-support-internal</artifactId>
-		</dependency>
-
 		<dependency>
 			<groupId>org.springframework.cloud.stream.app</groupId>
 			<artifactId>app-starters-test-support</artifactId>
 		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.integration</groupId>
-			<artifactId>spring-integration-test</artifactId>
-		</dependency>
-
 		<dependency>
 			<groupId>org.apache.sshd</groupId>
 			<artifactId>sshd-core</artifactId>
 		</dependency>
-
 		<dependency>
 			<groupId>org.springframework.cloud.stream.app</groupId>
 			<artifactId>app-starters-trigger-common</artifactId>
 		</dependency>
-
 	</dependencies>
 </project>

--- a/syslog/spring-cloud-starter-stream-source-syslog/pom.xml
+++ b/syslog/spring-cloud-starter-stream-source-syslog/pom.xml
@@ -18,21 +18,9 @@
 			<groupId>org.springframework.integration</groupId>
 			<artifactId>spring-integration-syslog</artifactId>
 		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream-test-support</artifactId>
-		</dependency>
-
 		<dependency>
 			<groupId>org.springframework.cloud.stream.app</groupId>
 			<artifactId>app-starters-test-support</artifactId>
 		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream</artifactId>
-		</dependency>
-
 	</dependencies>
 </project>

--- a/tcp/spring-cloud-starter-stream-sink-tcp/pom.xml
+++ b/tcp/spring-cloud-starter-stream-sink-tcp/pom.xml
@@ -18,31 +18,13 @@
 			<groupId>org.springframework.integration</groupId>
 			<artifactId>spring-integration-ip</artifactId>
 		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream</artifactId>
-		</dependency>
-
 		<dependency>
 			<groupId>org.springframework.cloud.stream.app</groupId>
 			<artifactId>app-starters-tcp-common</artifactId>
 		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream-test-support</artifactId>
-		</dependency>
-
 		<dependency>
 			<groupId>org.springframework.cloud.stream.app</groupId>
 			<artifactId>app-starters-test-support</artifactId>
 		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.integration</groupId>
-			<artifactId>spring-integration-test</artifactId>
-		</dependency>
-
 	</dependencies>
 </project>

--- a/tcp/spring-cloud-starter-stream-source-tcp/pom.xml
+++ b/tcp/spring-cloud-starter-stream-source-tcp/pom.xml
@@ -18,36 +18,17 @@
 			<groupId>org.springframework.integration</groupId>
 			<artifactId>spring-integration-ip</artifactId>
 		</dependency>
-
 		<dependency>
 			<groupId>org.springframework.integration</groupId>
 			<artifactId>spring-integration-java-dsl</artifactId>
 		</dependency>
-
 		<dependency>
 			<groupId>org.springframework.cloud.stream.app</groupId>
 			<artifactId>app-starters-tcp-common</artifactId>
 		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream-test-support</artifactId>
-		</dependency>
-
 		<dependency>
 			<groupId>org.springframework.cloud.stream.app</groupId>
 			<artifactId>app-starters-test-support</artifactId>
 		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.integration</groupId>
-			<artifactId>spring-integration-test</artifactId>
-		</dependency>
-
 	</dependencies>
 </project>

--- a/testing/spring-cloud-starter-stream-processor-integration-test/pom.xml
+++ b/testing/spring-cloud-starter-stream-processor-integration-test/pom.xml
@@ -13,21 +13,4 @@
 		<version>1.0.0.BUILD-SNAPSHOT</version>
 	</parent>
 
-	<dependencies>
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream-test-support</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.integration</groupId>
-			<artifactId>spring-integration-test</artifactId>
-		</dependency>
-
-	</dependencies>
 </project>

--- a/testing/spring-cloud-starter-stream-sink-throughput/pom.xml
+++ b/testing/spring-cloud-starter-stream-sink-throughput/pom.xml
@@ -18,26 +18,5 @@
 			<groupId>org.springframework.integration</groupId>
 			<artifactId>spring-integration-amqp</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream</artifactId>
-		</dependency>
-
-
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream-test-support</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream-test-support-internal</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.integration</groupId>
-			<artifactId>spring-integration-test</artifactId>
-		</dependency>
-
 	</dependencies>
 </project>

--- a/testing/spring-cloud-starter-stream-source-load-generator/pom.xml
+++ b/testing/spring-cloud-starter-stream-source-load-generator/pom.xml
@@ -22,30 +22,9 @@
 			<groupId>org.springframework.integration</groupId>
 			<artifactId>spring-integration-java-dsl</artifactId>
 		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream-test-support</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream-test-support-internal</artifactId>
-		</dependency>
-
 		<dependency>
 			<groupId>org.springframework.cloud.stream.app</groupId>
 			<artifactId>app-starters-test-support</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.integration</groupId>
-			<artifactId>spring-integration-test</artifactId>
 		</dependency>
 	</dependencies>
 </project>

--- a/time/spring-cloud-starter-stream-source-time/pom.xml
+++ b/time/spring-cloud-starter-stream-source-time/pom.xml
@@ -19,11 +19,6 @@
 			<artifactId>app-starters-time-common</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream-test-support</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
 			<groupId>org.springframework.cloud.stream.app</groupId>
 			<artifactId>app-starters-trigger-common</artifactId>
 		</dependency>

--- a/trigger/spring-cloud-starter-stream-source-trigger/pom.xml
+++ b/trigger/spring-cloud-starter-stream-source-trigger/pom.xml
@@ -19,10 +19,6 @@
 			<artifactId>app-starters-trigger-common</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream-test-support</artifactId>
-		</dependency>
-		<dependency>
 			<groupId>org.springframework.cloud.stream.app</groupId>
 			<artifactId>app-starters-annotation-common</artifactId>
 		</dependency>

--- a/twitter/spring-cloud-starter-stream-source-twitterstream/pom.xml
+++ b/twitter/spring-cloud-starter-stream-source-twitterstream/pom.xml
@@ -18,15 +18,9 @@
 			<groupId>org.springframework.cloud.stream.app</groupId>
 			<artifactId>app-starters-twitter-common</artifactId>
 		</dependency>
-
 		<dependency>
 			<groupId>org.springframework.social</groupId>
 			<artifactId>spring-social-twitter</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream-test-support</artifactId>
 		</dependency>
 	</dependencies>
 </project>

--- a/websocket/spring-cloud-starter-stream-sink-websocket/pom.xml
+++ b/websocket/spring-cloud-starter-stream-sink-websocket/pom.xml
@@ -18,36 +18,13 @@
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-websocket</artifactId>
 		</dependency>
-
 		<dependency>
 			<groupId>org.springframework.integration</groupId>
 			<artifactId>spring-integration-core</artifactId>
 		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream</artifactId>
-		</dependency>
-
 		<dependency>
 			<groupId>io.netty</groupId>
 			<artifactId>netty-all</artifactId>
 		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream-test-support</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream-test-support-internal</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.integration</groupId>
-			<artifactId>spring-integration-test</artifactId>
-		</dependency>
-
 	</dependencies>
 </project>


### PR DESCRIPTION
All the starters were individually having SCS and SI test dependencies.
Moving them to the parent
