### PR TITLE
Standardize on the use of commons logging API for logging purposes

### DIFF
--- a/app-starters-common-analytics/src/main/java/org/springframework/cloud/stream/app/retry/LoggingRecoveryCallback.java
+++ b/app-starters-common-analytics/src/main/java/org/springframework/cloud/stream/app/retry/LoggingRecoveryCallback.java
@@ -15,8 +15,8 @@
  */
 package org.springframework.cloud.stream.app.retry;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 import org.springframework.retry.RecoveryCallback;
 import org.springframework.retry.RetryContext;
@@ -29,7 +29,7 @@ import org.springframework.retry.RetryContext;
  */
 public class LoggingRecoveryCallback implements RecoveryCallback<Object> {
 
-	private static final Logger logger = LoggerFactory.getLogger(LoggingRecoveryCallback.class);
+	private static final Log logger = LogFactory.getLog(LoggingRecoveryCallback.class);
 
 	@Override
 	public Object recover(RetryContext context) throws Exception {

--- a/app-starters-common-analytics/src/main/java/org/springframework/cloud/stream/app/retry/RedisRetryTemplate.java
+++ b/app-starters-common-analytics/src/main/java/org/springframework/cloud/stream/app/retry/RedisRetryTemplate.java
@@ -15,8 +15,8 @@
  */
 package org.springframework.cloud.stream.app.retry;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 import org.springframework.data.redis.RedisSystemException;
 import org.springframework.data.redis.core.RedisCallback;
@@ -33,8 +33,7 @@ import org.springframework.retry.RetryOperations;
  */
 public class RedisRetryTemplate<K, V> extends RedisTemplate<K, V> {
 
-
-	private static final Logger logger = LoggerFactory.getLogger(RedisRetryTemplate.class);
+	private static final Log logger = LogFactory.getLog(RedisRetryTemplate.class);
 
 	private volatile RetryOperations retryOperations;
 

--- a/app-starters-common/app-starters-trigger-common/src/main/java/org/springframework/cloud/stream/app/trigger/DateTrigger.java
+++ b/app-starters-common/app-starters-trigger-common/src/main/java/org/springframework/cloud/stream/app/trigger/DateTrigger.java
@@ -21,8 +21,8 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 import org.springframework.scheduling.Trigger;
 import org.springframework.scheduling.TriggerContext;
@@ -38,7 +38,7 @@ public class DateTrigger implements Trigger {
 
 	private final List<Date> nextFireDates = new ArrayList<Date>();
 
-	private final Logger logger = LoggerFactory.getLogger(getClass());
+	private final Log logger = LogFactory.getLog(getClass());
 
 	public DateTrigger(Date... dates) {
 		for (Date date : dates) {

--- a/hdfs/spring-cloud-starter-stream-sink-hdfs-dataset/src/main/java/org/springframework/cloud/stream/app/hdfs/dataset/sink/HdfsDatasetSinkConfiguration.java
+++ b/hdfs/spring-cloud-starter-stream-sink-hdfs-dataset/src/main/java/org/springframework/cloud/stream/app/hdfs/dataset/sink/HdfsDatasetSinkConfiguration.java
@@ -16,11 +16,18 @@
 
 package org.springframework.cloud.stream.app.hdfs.dataset.sink;
 
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import javax.annotation.PreDestroy;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
 import org.apache.hadoop.fs.FileSystem;
 import org.kitesdk.data.PartitionStrategy;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+
 import org.springframework.beans.factory.FactoryBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -59,12 +66,6 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.util.StringUtils;
 
-import javax.annotation.PreDestroy;
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.List;
-
 /**
  * Configuration class for the HDFS DatasetSink.
  * <p/>
@@ -80,7 +81,7 @@ import java.util.List;
 @EnableConfigurationProperties(HdfsDatasetSinkProperties.class)
 public class HdfsDatasetSinkConfiguration {
 
-	protected static Logger logger = LoggerFactory.getLogger(HdfsDatasetSinkConfiguration.class);
+	private static final Log logger = LogFactory.getLog(HdfsDatasetSinkConfiguration.class);
 
 	@Autowired
 	private HdfsDatasetSinkProperties properties;
@@ -116,7 +117,7 @@ public class HdfsDatasetSinkConfiguration {
 				Object payload = message.getPayload();
 				if (payload instanceof Collection<?>) {
 					Collection<?> payloads = (Collection<?>) payload;
-					logger.debug("Writing a collection of {} POJOs", payloads.size());
+					logger.debug("Writing a collection of {} POJOs" + payloads.size());
 					datasetOperations.write((Collection<?>) message.getPayload());
 				}
 				else {

--- a/jdbc/spring-cloud-starter-stream-sink-jdbc/src/main/java/org/springframework/cloud/stream/app/jdbc/sink/DefaultInitializationScriptResource.java
+++ b/jdbc/spring-cloud-starter-stream-sink-jdbc/src/main/java/org/springframework/cloud/stream/app/jdbc/sink/DefaultInitializationScriptResource.java
@@ -16,11 +16,12 @@
 
 package org.springframework.cloud.stream.app.jdbc.sink;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.core.io.ByteArrayResource;
-
 import java.nio.charset.Charset;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.springframework.core.io.ByteArrayResource;
 
 /**
  * An in-memory script crafted for dropping-creating the table we're working with.
@@ -30,7 +31,7 @@ import java.nio.charset.Charset;
  */
 public class DefaultInitializationScriptResource extends ByteArrayResource {
 
-	private static final Logger logger = LoggerFactory.getLogger(DefaultInitializationScriptResource.class);
+	private static final Log logger = LogFactory.getLog(DefaultInitializationScriptResource.class);
 
 	public DefaultInitializationScriptResource(JdbcSinkProperties properties) {
 		super(scriptFor(properties).getBytes(Charset.forName("UTF-8")));
@@ -49,7 +50,8 @@ public class DefaultInitializationScriptResource extends ByteArrayResource {
 			result.append(column).append(" VARCHAR(2000)");
 		}
 		result.append(");\n");
-		logger.debug("Generated the following initializing script for table {}:\n{}", properties.getTableName(), result);
+		logger.debug(String.format("Generated the following initializing script for table %s:\n%s", properties.getTableName(),
+				result.toString()));
 		return result.toString();
 	}
 }

--- a/jdbc/spring-cloud-starter-stream-sink-jdbc/src/main/java/org/springframework/cloud/stream/app/jdbc/sink/JdbcSinkConfiguration.java
+++ b/jdbc/spring-cloud-starter-stream-sink-jdbc/src/main/java/org/springframework/cloud/stream/app/jdbc/sink/JdbcSinkConfiguration.java
@@ -16,9 +16,15 @@
 
 package org.springframework.cloud.stream.app.jdbc.sink;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.PostConstruct;
+import javax.sql.DataSource;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
 import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -46,11 +52,7 @@ import org.springframework.messaging.Message;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
-import javax.annotation.PostConstruct;
-import javax.sql.DataSource;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import com.fasterxml.jackson.databind.JsonNode;
 
 /**
  * A module that writes its incoming payload to an RDBMS using JDBC.
@@ -62,7 +64,7 @@ import java.util.Set;
 @EnableConfigurationProperties(JdbcSinkProperties.class)
 public class JdbcSinkConfiguration {
 
-	private static final Logger logger = LoggerFactory.getLogger(JdbcSinkConfiguration.class);
+	private static final Log logger = LogFactory.getLog(JdbcSinkConfiguration.class);
 
 	public static final Object NOT_SET = new Object();
 

--- a/metrics/spring-cloud-starter-stream-sink-counter/src/main/java/org/springframework/cloud/stream/app/counter/sink/CounterSinkConfiguration.java
+++ b/metrics/spring-cloud-starter-stream-sink-counter/src/main/java/org/springframework/cloud/stream/app/counter/sink/CounterSinkConfiguration.java
@@ -16,8 +16,8 @@
 
 package org.springframework.cloud.stream.app.counter.sink;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.metrics.CounterService;
@@ -44,7 +44,7 @@ import org.springframework.messaging.Message;
 @Import({ SpelExpressionConverterConfiguration.class, CounterSinkStoreConfiguration.class })
 public class CounterSinkConfiguration {
 
-	private static Logger logger = LoggerFactory.getLogger(CounterSinkConfiguration.class);
+	private static final Log logger = LogFactory.getLog(CounterSinkConfiguration.class);
 
 	@Autowired
 	private CounterService counterService;
@@ -58,7 +58,7 @@ public class CounterSinkConfiguration {
 	@ServiceActivator(inputChannel=Sink.INPUT)
 	public void count(Message<?> message) {
 		String name = computeMetricName(message);
-		logger.debug("Received: {}, about to increment counter named '{}'", message, name);
+		logger.debug(String.format("Received: %s, about to increment counter named '%s'", message, name));
 		counterService.increment(name);
 	}
 

--- a/pom.xml
+++ b/pom.xml
@@ -88,8 +88,13 @@
 		<dependency>
 			<groupId>org.springframework.integration</groupId>
 			<artifactId>spring-integration-xml</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>commons-logging</groupId>
+					<artifactId>commons-logging</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
-
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-stream-test-support</artifactId>
@@ -101,6 +106,10 @@
 		<dependency>
 			<groupId>org.springframework.integration</groupId>
 			<artifactId>spring-integration-test</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-logging</artifactId>
 		</dependency>
 	</dependencies>
 

--- a/processor/spring-cloud-starter-stream-processor-httpclient/src/main/java/org/springframework/cloud/stream/app/httpclient/processor/HttpclientProcessorConfiguration.java
+++ b/processor/spring-cloud-starter-stream-processor-httpclient/src/main/java/org/springframework/cloud/stream/app/httpclient/processor/HttpclientProcessorConfiguration.java
@@ -16,8 +16,13 @@
 
 package org.springframework.cloud.stream.app.httpclient.processor;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.net.URI;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.stream.annotation.EnableBinding;
@@ -34,10 +39,6 @@ import org.springframework.integration.annotation.MessageEndpoint;
 import org.springframework.integration.annotation.ServiceActivator;
 import org.springframework.messaging.Message;
 import org.springframework.web.client.RestTemplate;
-
-import java.net.URI;
-import java.util.Map;
-import java.util.Map.Entry;
 
 /**
  * A processor app that makes requests to an HTTP resource and emits the
@@ -67,7 +68,7 @@ public class HttpclientProcessorConfiguration {
 	@MessageEndpoint
 	public static class HttpClientProcessor {
 
-		private static final Logger LOG = LoggerFactory.getLogger(HttpClientProcessor.class);
+		private static final Log LOG = LogFactory.getLog(HttpClientProcessor.class);
 
 		@Autowired
 		private HttpclientProcessorProperties properties;

--- a/processor/spring-cloud-starter-stream-processor-scriptable-transform/src/main/java/org/springframework/cloud/stream/app/scriptable/transform/processor/ScriptableTransformProcessorConfiguration.java
+++ b/processor/spring-cloud-starter-stream-processor-scriptable-transform/src/main/java/org/springframework/cloud/stream/app/scriptable/transform/processor/ScriptableTransformProcessorConfiguration.java
@@ -17,8 +17,8 @@ package org.springframework.cloud.stream.app.scriptable.transform.processor;
 
 import java.util.regex.Matcher;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -54,7 +54,7 @@ public class ScriptableTransformProcessorConfiguration {
 
 	private static final String DOUBLE_DOUBLE_QUOTE = Matcher.quoteReplacement("\"\"");
 
-	private static Logger logger = LoggerFactory.getLogger(ScriptableTransformProcessorConfiguration.class);
+	private static final Log logger = LogFactory.getLog(ScriptableTransformProcessorConfiguration.class);
 
 	@Autowired
 	private ScriptVariableGenerator scriptVariableGenerator;
@@ -67,7 +67,7 @@ public class ScriptableTransformProcessorConfiguration {
 	public MessageProcessor<?> transformer() {
 		String language = this.properties.getLanguage();
 		String script = this.properties.getScript();
-		logger.info("Input script is '{}', language is '{}'", script, language);
+		logger.info(String.format("Input script is '%s', language is '%s'", script, language));
 		Resource scriptResource = new ByteArrayResource(decodeScript(script).getBytes()) {
 
 			// TODO until INT-3976

--- a/tcp/spring-cloud-starter-stream-sink-tcp/src/test/java/org/springframework/cloud/stream/app/tcp/sink/TcpSinkTests.java
+++ b/tcp/spring-cloud-starter-stream-sink-tcp/src/test/java/org/springframework/cloud/stream/app/tcp/sink/TcpSinkTests.java
@@ -37,8 +37,8 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -235,7 +235,7 @@ public abstract class TcpSinkTests {
 	 */
 	private static class TestTCPServer implements Runnable {
 
-		private static final Logger logger = LoggerFactory.getLogger(TestTCPServer.class);
+		private static final Log logger = LogFactory.getLog(TestTCPServer.class);
 
 		private final ServerSocket serverSocket;
 

--- a/testing/spring-cloud-starter-stream-source-load-generator/src/main/java/org/springframework/cloud/stream/app/load/generator/source/LoadGeneratorSourceConfiguration.java
+++ b/testing/spring-cloud-starter-stream-source-load-generator/src/main/java/org/springframework/cloud/stream/app/load/generator/source/LoadGeneratorSourceConfiguration.java
@@ -20,8 +20,8 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -42,7 +42,7 @@ import org.springframework.messaging.support.GenericMessage;
 @EnableConfigurationProperties({LoadGeneratorSourceProperties.class})
 public class LoadGeneratorSourceConfiguration extends AbstractEndpoint {
 
-	private static final Logger logger = LoggerFactory.getLogger(LoadGeneratorSourceConfiguration.class);
+	private static final Log logger = LogFactory.getLog(LoadGeneratorSourceConfiguration.class);
 
 	@Autowired
 	private LoadGeneratorSourceProperties properties;
@@ -89,7 +89,7 @@ public class LoadGeneratorSourceConfiguration extends AbstractEndpoint {
 
 		@Override
 		public void run() {
-			logger.info("Producer {} sending {} messages", this.producerId, this.messageCount);
+			logger.info(String.format("Producer %d sending %d messages", this.producerId, this.messageCount));
 			Message<byte[]> message = new GenericMessage<>(new byte[this.messageSize]);
 			for (int i = 0; i < this.messageCount; i++) {
 				channel.output().send(message);


### PR DESCRIPTION
Exclude commons-logging artifact depdendency, but use commons logging API through jcl-over-slf4j

Use spring-boot-starter-logging dependency for all logging which uses slf4j and
delegate any commons logging API calls to Slf4j using jcl-over-slf4j.

Polishing import order

Resolves #11 
