### PR TITLE
GH-79: Add AWS Integration tests module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ spring-xd-samples/*/xd
 dump.rdb
 coverage-error.log
 .apt_generated
+aws.credentials.properties

--- a/aws-integration-tests/README.adoc
+++ b/aws-integration-tests/README.adoc
@@ -1,0 +1,36 @@
+= Spring Cloud Stream Application Starters AWS Integration Tests
+
+This module contains a test-suite which runs integration tests to ensure compatibility with the Amazon Web Services.
+In order to run the integration tests, the build process has to create different resources on the Amazon Webservice platform (Amazon EC2 instances, Amazon RDS instances, Amazon S3 Buckets, Amazon SQS Queues).
+Creating these resources takes time and costs money, because every instance creation is charged with a one hour usage.
+Therefore Spring Cloud AWS does not execute the integration tests by default.
+
+In order to execute the integration tests you have to create credentials configuration files that configure the necessary parameters to build the environment.
+
+Please create a new file named `aws.credentials.properties` in any desired place and provide the path as a `aws.credentials.path` Maven command argument (see below).
+The `accessKey` and `secretKey` are account/user specific and should never be shared to anyone.
+To retrieve these settings you have to open your account inside the AWS console and retrieve them through the https://portal.aws.amazon.com/gp/aws/securityCredentials[Security Credentials Page].
+_Note:_ In general we recommend that you use an https://aws.amazon.com/iam/[Amazon IAM] user instead of the account itself.
+
+An example file will look like this
+
+-------------------------------------------
+cloud.aws.credentials.accessKey=ilaugsjdlkahgsdlaksdhg
+cloud.aws.credentials.secretKey=aöksjdhöadjs,höalsdhjköalsdjhasd+
+-------------------------------------------
+
+After creating the `aws.credentials.properties` file and storing it outside the project (or inside the project, they are ignored in git) you have to provide the configuration directory when running the build.
+Providing these configuration settings will automatically execute the integration tests.
+
+To build with the integration tests you must execute
+
+-----------------------------------------------------------------------------------------------------
+mvnw -pl :spring-cloud-starter-stream-aws-integration-tests verify -Daws.credentials.path=/Users/foo/config/dir
+-----------------------------------------------------------------------------------------------------
+
+The integration test will create an https://aws.amazon.com/de/cloudformation/[Amazon Web Services CloudFormation] stack and execute the tests.
+The stack is destroyed after executing the tests (either successful or failed) to ensure that there are no unnecessary costs.
+
+== Costs of integration tests
+
+The costs for one integration test run should not be more then 0.40 $ per hour (excl. VAT).

--- a/aws-integration-tests/pom.xml
+++ b/aws-integration-tests/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<artifactId>spring-cloud-stream-app-starters</artifactId>
+		<groupId>org.springframework.cloud.stream.app</groupId>
+		<version>1.0.0.BUILD-SNAPSHOT</version>
+	</parent>
+
+	<name>spring-cloud-starter-stream-aws-integration-tests</name>
+	<description>Spring Cloud Stream Starters Amazon Integration Tests</description>
+	<artifactId>spring-cloud-starter-stream-aws-integration-tests</artifactId>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.cloud.stream.app</groupId>
+			<artifactId>spring-cloud-starter-stream-sink-s3</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.cloud.stream.app</groupId>
+			<artifactId>spring-cloud-starter-stream-source-s3</artifactId>
+		</dependency>
+
+		<!-- Test Scope -->
+		<dependency>
+			<groupId>org.springframework.cloud.stream.app</groupId>
+			<artifactId>app-starters-test-support</artifactId>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-failsafe-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/aws-integration-tests/src/test/java/org/springframework/cloud/stream/app/aws/AwsIntegrationTestStackRule.java
+++ b/aws-integration-tests/src/test/java/org/springframework/cloud/stream/app/aws/AwsIntegrationTestStackRule.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.app.aws;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.InputStreamReader;
+import java.util.List;
+import java.util.Properties;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.junit.Assume;
+import org.junit.AssumptionViolatedException;
+import org.junit.rules.ExternalResource;
+
+import org.springframework.beans.factory.config.YamlPropertiesFactoryBean;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.FileCopyUtils;
+
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.cloudformation.AmazonCloudFormation;
+import com.amazonaws.services.cloudformation.AmazonCloudFormationClient;
+import com.amazonaws.services.cloudformation.model.CreateStackRequest;
+import com.amazonaws.services.cloudformation.model.DeleteStackRequest;
+import com.amazonaws.services.cloudformation.model.DescribeStacksRequest;
+import com.amazonaws.services.cloudformation.model.OnFailure;
+import com.amazonaws.services.cloudformation.model.Stack;
+import com.amazonaws.services.cloudformation.model.StackStatus;
+
+/**
+ * @author Artem Bilan
+ */
+public class AwsIntegrationTestStackRule extends ExternalResource {
+
+	private static final Log logger = LogFactory.getLog(AwsIntegrationTestStackRule.class);
+
+	private AmazonCloudFormation cloudFormation;
+
+	private String stackName;
+
+	@Override
+	protected void before() throws Throwable {
+		try {
+			String awsCredentialsDir = System.getProperty("aws.credentials.path");
+			File awsCredentialsFile = new File(awsCredentialsDir, "aws.credentials.properties");
+			Properties awsCredentials = new Properties();
+			awsCredentials.load(new FileReader(awsCredentialsFile));
+			String accessKey = awsCredentials.getProperty("cloud.aws.credentials.accessKey");
+			String secretKey = awsCredentials.getProperty("cloud.aws.credentials.secretKey");
+			this.cloudFormation = new AmazonCloudFormationClient(new BasicAWSCredentials(accessKey, secretKey));
+
+			YamlPropertiesFactoryBean yamlPropertiesFactoryBean = new YamlPropertiesFactoryBean();
+			yamlPropertiesFactoryBean.setResources(new ClassPathResource("application.yml"));
+			Properties applicationProperties = yamlPropertiesFactoryBean.getObject();
+
+			this.stackName = applicationProperties.getProperty("cloud.aws.stack.name");
+
+			after();
+
+			ClassPathResource stackTemplate = new ClassPathResource("AwsIntegrationTestTemplate.json");
+			String templateBody = FileCopyUtils.copyToString(new InputStreamReader(stackTemplate.getInputStream()));
+
+			this.cloudFormation.createStack(
+					new CreateStackRequest()
+							.withTemplateBody(templateBody)
+							.withOnFailure(OnFailure.DELETE)
+							.withStackName(this.stackName));
+
+			waitForCompletion();
+
+			System.setProperty("cloud.aws.credentials.accessKey", accessKey);
+			System.setProperty("cloud.aws.credentials.secretKey", secretKey);
+		}
+		catch (Exception e) {
+			if (!(e instanceof AssumptionViolatedException)) {
+				Assume.assumeTrue("Can't perform AWS integration test because of: " + e.getMessage(), false);
+			}
+			else {
+				throw e;
+			}
+		}
+	}
+
+	@Override
+	protected void after() {
+		this.cloudFormation.deleteStack(new DeleteStackRequest().withStackName(this.stackName));
+		try {
+			waitForCompletion();
+		}
+		catch (InterruptedException e) {
+			// Ignore the InterruptedException
+		}
+	}
+
+	// Wait for a stack to complete transitioning
+	// End stack states are:
+	//    CREATE_COMPLETE
+	//    CREATE_FAILED
+	//    DELETE_FAILED
+	//    ROLLBACK_FAILED
+	// OR the stack no longer exists
+	private void waitForCompletion() throws InterruptedException {
+		DescribeStacksRequest wait = new DescribeStacksRequest();
+		wait.setStackName(this.stackName);
+		Boolean completed = false;
+		String stackStatus = "Unknown";
+		String stackReason = "";
+
+		while (!completed) {
+			List<Stack> stacks = null;
+			try {
+				stacks = this.cloudFormation.describeStacks(wait).getStacks();
+			}
+			catch (Exception e) {
+				logger.error("cloudFormation.describeStacks() exception", e);
+			}
+			if (CollectionUtils.isEmpty(stacks)) {
+				completed = true;
+				stackStatus = StackStatus.DELETE_COMPLETE.toString();
+				stackReason = "Stack has been deleted";
+			}
+			else {
+				for (Stack stack : stacks) {
+					if (stack.getStackStatus().equals(StackStatus.CREATE_COMPLETE.toString()) ||
+							stack.getStackStatus().equals(StackStatus.CREATE_FAILED.toString()) ||
+							stack.getStackStatus().equals(StackStatus.ROLLBACK_FAILED.toString()) ||
+							stack.getStackStatus().equals(StackStatus.DELETE_FAILED.toString())) {
+						completed = true;
+						stackStatus = stack.getStackStatus();
+						stackReason = stack.getStackStatusReason();
+					}
+				}
+			}
+
+			// Not done yet so sleep for 2 seconds.
+			if (!completed) {
+				Thread.sleep(2000);
+			}
+			else {
+				if (stackStatus.equals(StackStatus.CREATE_FAILED.toString())) {
+					Assume.assumeTrue("The test AWS stack [" + this.stackName + "] cannot be created. Reason: " +
+									stackReason, true);
+				}
+			}
+		}
+	}
+
+}

--- a/aws-integration-tests/src/test/java/org/springframework/cloud/stream/app/aws/SpringCloudStreamAwsApplicationsITCase.java
+++ b/aws-integration-tests/src/test/java/org/springframework/cloud/stream/app/aws/SpringCloudStreamAwsApplicationsITCase.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.app.aws;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.springframework.integration.test.matcher.HeaderMatcher.hasHeader;
+import static org.springframework.integration.test.matcher.PayloadMatcher.hasPayload;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.After;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.cloud.aws.core.env.ResourceIdResolver;
+import org.springframework.cloud.stream.app.s3.source.AmazonS3SourceConfiguration;
+import org.springframework.cloud.stream.messaging.Source;
+import org.springframework.cloud.stream.test.binder.MessageCollector;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.integration.file.FileHeaders;
+import org.springframework.messaging.Message;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+
+/**
+ * @author Artem Bilan
+ */
+public class SpringCloudStreamAwsApplicationsITCase {
+
+	@ClassRule
+	public static final AwsIntegrationTestStackRule TEST_STACK_RULE = new AwsIntegrationTestStackRule();
+
+	private ConfigurableApplicationContext applicationContext;
+
+	@After
+	public void after() {
+		if (this.applicationContext != null) {
+			this.applicationContext.close();
+		}
+	}
+
+	@Test
+	public void testS3Source() throws IOException, InterruptedException {
+		String bucket = "TestBucket";
+		String key = "foo";
+		String content = "Spring Cloud Stream AWS S3 Source test";
+
+		this.applicationContext = SpringApplication.run(S3SourceBootConfiguration.class,
+				"--remoteDir=" + bucket, "--mode=lines", "--with-markers=false");
+
+		ResourceIdResolver resourceIdResolver = this.applicationContext.getBean(ResourceIdResolver.class);
+
+		AmazonS3 amazonS3 = this.applicationContext.getBean(AmazonS3.class);
+		ObjectMetadata objectMetadata = new ObjectMetadata();
+		objectMetadata.setContentLength(content.length());
+		String bucketName = resourceIdResolver.resolveToPhysicalResourceId(bucket);
+		amazonS3.putObject(bucketName, key, new ByteArrayInputStream(content.getBytes("UTF-8")), objectMetadata);
+
+		Source source = this.applicationContext.getBean(Source.class);
+		MessageCollector messageCollector = this.applicationContext.getBean(MessageCollector.class);
+		Message<?> received = messageCollector.forChannel(source.output()).poll(10, TimeUnit.SECONDS);
+		assertNotNull(received);
+		assertThat(received, hasHeader(FileHeaders.FILENAME, key));
+		assertThat(received, hasPayload("Spring Cloud Stream AWS S3 Source test"));
+	}
+
+	@Configuration
+	@EnableAutoConfiguration
+	@Import(AmazonS3SourceConfiguration.class)
+	public static class S3SourceBootConfiguration {
+
+	}
+
+}

--- a/aws-integration-tests/src/test/resources/AwsIntegrationTestTemplate.json
+++ b/aws-integration-tests/src/test/resources/AwsIntegrationTestTemplate.json
@@ -1,0 +1,9 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "Spring Cloud Stream App Starters AWS Integration Test Template",
+  "Resources": {
+    "TestBucket": {
+      "Type": "AWS::S3::Bucket"
+    }
+  }
+}

--- a/aws-integration-tests/src/test/resources/application.yml
+++ b/aws-integration-tests/src/test/resources/application.yml
@@ -1,0 +1,6 @@
+cloud:
+  aws:
+    region:
+      static: us-east-1
+    stack:
+      name: IntegrationTestStack

--- a/aws-s3/spring-cloud-starter-stream-source-s3/README.adoc
+++ b/aws-s3/spring-cloud-starter-stream-source-s3/README.adoc
@@ -53,6 +53,11 @@ Other are for AWS `Region` definition:
 - cloud.aws.region.auto
 - cloud.aws.region.static
 
+And for AWS `Stack`:
+
+- cloud.aws.stack.auto
+- cloud.aws.stack.name
+
 //end::ref-doc[]
 == Build
 

--- a/aws-s3/spring-cloud-starter-stream-source-s3/src/main/java/org/springframework/cloud/stream/app/s3/source/AmazonS3SourceConfiguration.java
+++ b/aws-s3/spring-cloud-starter-stream-source-s3/src/main/java/org/springframework/cloud/stream/app/s3/source/AmazonS3SourceConfiguration.java
@@ -18,6 +18,7 @@ package org.springframework.cloud.stream.app.s3.source;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.cloud.aws.core.env.ResourceIdResolver;
 import org.springframework.cloud.stream.annotation.EnableBinding;
 import org.springframework.cloud.stream.app.file.FileConsumerProperties;
 import org.springframework.cloud.stream.app.file.FileUtils;
@@ -50,12 +51,16 @@ public class AmazonS3SourceConfiguration {
 	@Autowired
 	private AmazonS3 amazonS3;
 
+	@Autowired
+	private ResourceIdResolver resourceIdResolver;
+
 	@Bean
 	public S3InboundFileSynchronizer s3InboundFileSynchronizer() {
 		S3InboundFileSynchronizer synchronizer = new S3InboundFileSynchronizer(this.amazonS3);
 		synchronizer.setDeleteRemoteFiles(this.s3SourceProperties.isDeleteRemoteFiles());
 		synchronizer.setPreserveTimestamp(this.s3SourceProperties.isPreserveTimestamp());
-		synchronizer.setRemoteDirectory(this.s3SourceProperties.getRemoteDir());
+		String remoteDir = this.s3SourceProperties.getRemoteDir();
+		synchronizer.setRemoteDirectory(this.resourceIdResolver.resolveToPhysicalResourceId(remoteDir));
 		synchronizer.setRemoteFileSeparator(this.s3SourceProperties.getRemoteFileSeparator());
 		synchronizer.setTemporaryFileSuffix(this.s3SourceProperties.getTmpFileSuffix());
 

--- a/aws-s3/spring-cloud-starter-stream-source-s3/src/test/java/org/springframework/cloud/stream/app/s3/source/AmazonS3SourceMockTests.java
+++ b/aws-s3/spring-cloud-starter-stream-source-s3/src/test/java/org/springframework/cloud/stream/app/s3/source/AmazonS3SourceMockTests.java
@@ -33,6 +33,7 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.List;
+import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.AfterClass;
@@ -229,18 +230,18 @@ public abstract class AmazonS3SourceMockTests {
 		@Test
 		@Override
 		public void test() throws Exception {
-			Message<?> received = this.messageCollector.forChannel(this.channels.output())
-					.poll(10, TimeUnit.SECONDS);
+			BlockingQueue<Message<?>> messages = this.messageCollector.forChannel(this.channels.output());
+			Message<?> received = messages.poll(10, TimeUnit.SECONDS);
 			assertNotNull(received);
 			assertThat(received, hasPayload("Other"));
 			assertThat(received,
 					hasHeader(FileHeaders.ORIGINAL_FILE, new File(this.config.getLocalDir(), "otherFile")));
 
-			received = this.messageCollector.forChannel(this.channels.output()).poll(10, TimeUnit.SECONDS);
+			received = messages.poll(10, TimeUnit.SECONDS);
 			assertNotNull(received);
 			assertThat(received, hasPayload("Other2"));
 
-			assertNull(this.messageCollector.forChannel(this.channels.output()).poll(10, TimeUnit.MILLISECONDS));
+			assertNull(messages.poll(10, TimeUnit.MILLISECONDS));
 
 			assertEquals(1, this.config.getLocalDir().list().length);
 		}

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,7 @@
 		<module>app-starters-common</module>
 		<module>app-starters-common-analytics</module>
 		<module>app-starters-test-support</module>
+		<module>aws-integration-tests</module>
 		<module>aws-s3</module>
 		<module>cassandra</module>
 		<module>cloudfoundry</module>


### PR DESCRIPTION
Fixes GH-79 (https://github.com/spring-cloud/spring-cloud-stream-app-starters/issues/79)

The real testing against AWS is based on the Cloud Formation and Stack templating.
- Add module `spring-cloud-starter-stream-aws-integration-tests`
- Include `maven-failsafe-plugin` to run Integration Tests in safe mode and don't run them with the Surefire plugin.
- Provide the ability to read AWS credentials from an external properties file. See README.adoc in the module.
- Add Cloud Formation Stack template - `AwsIntegrationTestTemplate.json`
- Add `AwsIntegrationTestStackRule` JUnit Rule to read AWS credentials, store them in the `System.properties` and create and remove the test Stack around target test class.
- Add `S3Source` test: stores a content in the `TestBucket` and the `S3Source` application poll it with the `mode=lines`.
- Fix `AmazonS3SourceConfiguration` to accept `ResourceIdResolver` to resolve the real S3 bucket against the AWS stack in which our application is ran.
