### PR TITLE
Fixing docs build due to a spring cloud stream modules reference

### DIFF
--- a/spring-cloud-stream-app-starters-docs/pom.xml
+++ b/spring-cloud-stream-app-starters-docs/pom.xml
@@ -196,7 +196,7 @@
 								</goals>
 								<configuration>
 									<target>
-										<zip destfile="${project.build.directory}/spring-cloud-stream-modules-${project.version}.zip">
+										<zip destfile="${project.build.directory}/spring-cloud-stream-app-starters-docs-${project.version}.jar">
 											<fileset dir="${project.build.directory}/contents" />
 										</zip>
 									</target>
@@ -240,7 +240,7 @@
 								<configuration>
 									<artifacts>
 										<artifact>
-											<file>${project.build.directory}/spring-cloud-stream-modules-${project.version}.zip</file>
+											<file>${project.build.directory}/spring-cloud-stream-app-starters-docs-${project.version}.jar</file>
 											<type>zip;zip.type=docs;zip.deployed=false</type>
 										</artifact>
 									</artifacts>


### PR DESCRIPTION
Build with -Pfull fails due to a reference to spring cloud stream modules docs zip file.

Resolves #104 
