### PR TITLE
FileSplitter: add `markersJson` option

### DIFF
--- a/app-starters-common/app-starters-file-common/src/main/java/org/springframework/cloud/stream/app/file/FileConsumerProperties.java
+++ b/app-starters-common/app-starters-file-common/src/main/java/org/springframework/cloud/stream/app/file/FileConsumerProperties.java
@@ -33,7 +33,7 @@ public class FileConsumerProperties {
 	 * 'contents' - the contents as bytes.
 	 * Default is 'contents'
 	 */
-	private FileReadingMode fileReadingMode = FileReadingMode.contents;
+	private FileReadingMode mode = FileReadingMode.contents;
 
 	/**
 	 * 	Set to true to emit start of file/end of file marker messages before/after the data.
@@ -50,11 +50,11 @@ public class FileConsumerProperties {
 
 	@NotNull
 	public FileReadingMode getMode() {
-		return this.fileReadingMode;
+		return this.mode;
 	}
 
 	public void setMode(FileReadingMode mode) {
-		this.fileReadingMode = mode;
+		this.mode = mode;
 	}
 
 	public Boolean getWithMarkers() {
@@ -75,7 +75,7 @@ public class FileConsumerProperties {
 
 	@AssertTrue(message = "withMarkers can only be supplied when FileReadingMode is 'lines'")
 	public boolean isWithMarkersValid() {
-		return !(this.withMarkers != null && FileReadingMode.lines != this.fileReadingMode);
+		return !(this.withMarkers != null && FileReadingMode.lines != this.mode);
 	}
 
 }

--- a/app-starters-common/app-starters-file-common/src/main/java/org/springframework/cloud/stream/app/file/FileConsumerProperties.java
+++ b/app-starters-common/app-starters-file-common/src/main/java/org/springframework/cloud/stream/app/file/FileConsumerProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2016 the original author or authors.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -22,6 +22,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**
  * @author David Turanski
+ * @author Artem Bilan
  */
 @ConfigurationProperties("file.consumer")
 public class FileConsumerProperties {
@@ -31,7 +32,6 @@ public class FileConsumerProperties {
 	 * Values are 'ref' - The File object,
 	 * 'lines' - a message per line, or
 	 * 'contents' - the contents as bytes.
-	 * Default is 'contents'
 	 */
 	private FileReadingMode mode = FileReadingMode.contents;
 
@@ -42,11 +42,10 @@ public class FileConsumerProperties {
 	private Boolean withMarkers = null;
 
 	/**
-	 * When {@code fileMarkers == true}, specify if they should be produced
-	 * as {@link org.springframework.integration.file.splitter.FileSplitter.FileMarker}
-	 * objects or JSON.
+	 * When 'fileMarkers == true', specify if they should be produced
+	 * as FileSplitter.FileMarker objects or JSON.
 	 */
-	private boolean markersJson = false;
+	private boolean markersJson = true;
 
 	@NotNull
 	public FileReadingMode getMode() {
@@ -75,7 +74,7 @@ public class FileConsumerProperties {
 
 	@AssertTrue(message = "withMarkers can only be supplied when FileReadingMode is 'lines'")
 	public boolean isWithMarkersValid() {
-		return !(this.withMarkers != null && FileReadingMode.lines != this.mode);
+		return this.withMarkers == null || FileReadingMode.lines == this.mode;
 	}
 
 }

--- a/app-starters-common/app-starters-file-common/src/main/java/org/springframework/cloud/stream/app/file/FileConsumerProperties.java
+++ b/app-starters-common/app-starters-file-common/src/main/java/org/springframework/cloud/stream/app/file/FileConsumerProperties.java
@@ -15,10 +15,10 @@
 
 package org.springframework.cloud.stream.app.file;
 
-import org.springframework.boot.context.properties.ConfigurationProperties;
-
 import javax.validation.constraints.AssertTrue;
 import javax.validation.constraints.NotNull;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**
  * @author David Turanski
@@ -33,49 +33,49 @@ public class FileConsumerProperties {
 	 * 'contents' - the contents as bytes.
 	 * Default is 'contents'
 	 */
-	private FileReadingMode fileReadingmode = FileReadingMode.contents;
+	private FileReadingMode fileReadingMode = FileReadingMode.contents;
 
 	/**
-	 * 	Set to true to emit start of file/end of file marker messages before/after the data. 
+	 * 	Set to true to emit start of file/end of file marker messages before/after the data.
 	 * 	Only valid with FileReadingMode 'lines'.
 	 */
 	private Boolean withMarkers = null;
 
+	/**
+	 * When {@code fileMarkers == true}, specify if they should be produced
+	 * as {@link org.springframework.integration.file.splitter.FileSplitter.FileMarker}
+	 * objects or JSON.
+	 */
+	private boolean markersJson = false;
+
 	@NotNull
 	public FileReadingMode getMode() {
-		return fileReadingmode;
+		return this.fileReadingMode;
 	}
 
 	public void setMode(FileReadingMode mode) {
-		this.fileReadingmode = mode;
+		this.fileReadingMode = mode;
 	}
 
 	public Boolean getWithMarkers() {
-		return withMarkers;
+		return this.withMarkers;
 	}
 
 	public void setWithMarkers(Boolean withMarkers) {
 		this.withMarkers = withMarkers;
 	}
 
-	@AssertTrue(message = "withMarkers can only be supplied when FileReadingMode is 'lines'")
-	public boolean isWithMarkersValid() {
-		if (this.withMarkers != null && FileReadingMode.lines != this.fileReadingmode) {
-			return false;
-		}
-		else {
-			return true;
-		}
+	public boolean getMarkersJson() {
+		return this.markersJson;
 	}
 
-	@AssertTrue(message = "withMarkers must be set when FileReadingMode is 'lines'")
-	public boolean isWithMarkersMustBeSet() {
-		if (this.withMarkers == null && FileReadingMode.lines == this.fileReadingmode) {
-			return false;
-		}
-		else {
-			return true;
-		}
+	public void setMarkersJson(boolean markersJson) {
+		this.markersJson = markersJson;
+	}
+
+	@AssertTrue(message = "withMarkers can only be supplied when FileReadingMode is 'lines'")
+	public boolean isWithMarkersValid() {
+		return !(this.withMarkers != null && FileReadingMode.lines != this.fileReadingMode);
 	}
 
 }

--- a/app-starters-common/app-starters-file-common/src/main/java/org/springframework/cloud/stream/app/file/FileUtils.java
+++ b/app-starters-common/app-starters-file-common/src/main/java/org/springframework/cloud/stream/app/file/FileUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,17 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.cloud.stream.app.file;
 
-import org.springframework.integration.dsl.IntegrationFlowBuilder;
-import org.springframework.integration.dsl.file.Files;
-import org.springframework.integration.dsl.support.Transformers;
-import org.springframework.messaging.MessageHeaders;
+package org.springframework.cloud.stream.app.file;
 
 import java.util.Collections;
 
+import org.springframework.integration.dsl.IntegrationFlowBuilder;
+import org.springframework.integration.dsl.support.Transformers;
+import org.springframework.integration.file.splitter.FileSplitter;
+import org.springframework.messaging.MessageHeaders;
+
 /**
  * @author Gary Russell
+ * @author Artem Bilan
  *
  */
 public class FileUtils {
@@ -44,9 +46,13 @@ public class FileUtils {
 					.transform(Transformers.fileToByteArray());
 			break;
 		case lines:
+			Boolean withMarkers = fileConsumerProperties.getWithMarkers();
+			if (withMarkers == null) {
+				withMarkers = false;
+			}
 			flowBuilder.enrichHeaders(Collections.<String, Object>singletonMap(MessageHeaders.CONTENT_TYPE,
 					"text/plain"))
-					.split(Files.splitter(true, fileConsumerProperties.getWithMarkers()));
+					.split(new FileSplitter(true, withMarkers, fileConsumerProperties.getMarkersJson()));
 		case ref:
 			break;
 		default:

--- a/file/spring-cloud-starter-stream-source-file/README.adoc
+++ b/file/spring-cloud-starter-stream-source-file/README.adoc
@@ -26,7 +26,7 @@ $$pattern$$:: $$a filter expression (Ant style) to accept only files that match 
 $$preventDuplicates$$:: $$whether to prevent the same file from being processed twice$$ *($$boolean$$, default: `true`)*
 $$timeUnit$$:: $$the time unit for the fixed and initial delays$$ *($$String$$, default: `SECONDS`)*
 $$withMarkers$$:: $$if true emits start of file/end of file marker messages before/after the data. Only valid with FileReadingMode 'lines'$$ *($$Boolean$$, no default)*
-$$markersJson$$:: $$if `true` emits file markers as JSON String. Only applied when FileReadingMode is 'lines'$$ *($$boolean$$, default: `false`)*
+$$markersJson$$:: $$if `true` emits file markers as JSON String. Only applied when FileReadingMode is 'lines'$$ *($$boolean$$, default: `true`)*
 
 The `ref` option is useful in some cases in which the file contents are large and it would be more efficient to send the file path.
 

--- a/file/spring-cloud-starter-stream-source-file/README.adoc
+++ b/file/spring-cloud-starter-stream-source-file/README.adoc
@@ -26,6 +26,7 @@ $$pattern$$:: $$a filter expression (Ant style) to accept only files that match 
 $$preventDuplicates$$:: $$whether to prevent the same file from being processed twice$$ *($$boolean$$, default: `true`)*
 $$timeUnit$$:: $$the time unit for the fixed and initial delays$$ *($$String$$, default: `SECONDS`)*
 $$withMarkers$$:: $$if true emits start of file/end of file marker messages before/after the data. Only valid with FileReadingMode 'lines'$$ *($$Boolean$$, no default)*
+$$markersJson$$:: $$if `true` emits file markers as JSON String. Only applied when FileReadingMode is 'lines'$$ *($$boolean$$, default: `false`)*
 
 The `ref` option is useful in some cases in which the file contents are large and it would be more efficient to send the file path.
 

--- a/file/spring-cloud-starter-stream-source-file/src/test/java/org/springframework/cloud/stream/app/file/source/FileSourceTests.java
+++ b/file/spring-cloud-starter-stream-source-file/src/test/java/org/springframework/cloud/stream/app/file/source/FileSourceTests.java
@@ -107,7 +107,7 @@ public abstract class FileSourceTests {
 	}
 
 	@IntegrationTest({"file.directory = ${java.io.tmpdir}${file.separator}dataflow-tests${file.separator}input",
-			"trigger.fixedDelay = 100", "trigger.timeUnit = MILLISECONDS", "file.consumer.mode = lines", "file.consumer.withMarkers = false"})
+			"trigger.fixedDelay = 100", "trigger.timeUnit = MILLISECONDS", "file.consumer.mode = lines"})
 	public static class LinesPayloadTests extends FileSourceTests {
 
 		@Test
@@ -127,7 +127,8 @@ public abstract class FileSourceTests {
 	}
 
 	@IntegrationTest({"file.directory = ${java.io.tmpdir}${file.separator}dataflow-tests${file.separator}input",
-			"trigger.fixedDelay = 100", "trigger.timeUnit = MILLISECONDS", "file.consumer.mode = lines", "file.consumer.withMarkers = true"})
+			"trigger.fixedDelay = 100", "trigger.timeUnit = MILLISECONDS", "file.consumer.mode = lines",
+			"file.consumer.withMarkers = true"})
 	public static class LinesAndMarkersPayloadTests extends FileSourceTests {
 
 		@Test
@@ -154,9 +155,9 @@ public abstract class FileSourceTests {
 
 	}
 
-	@IntegrationTest({"directory = ${java.io.tmpdir}${file.separator}dataflow-tests${file.separator}input",
-			"fixedDelay = 100", "timeUnit = MILLISECONDS", "mode = lines", "withMarkers = true",
-			"markersJson = true"})
+	@IntegrationTest({"file.directory = ${java.io.tmpdir}${file.separator}dataflow-tests${file.separator}input",
+			"trigger.fixedDelay = 100", "trigger.timeUnit = MILLISECONDS", "file.consumer.mode = lines",
+			"file.consumer.withMarkers = true", "file.consumer.markersJson = true"})
 	public static class LinesAndMarkersAsJsonPayloadTests extends FileSourceTests {
 
 		@Test
@@ -191,8 +192,9 @@ public abstract class FileSourceTests {
 	}
 
 
-	@IntegrationTest({"directory = ${java.io.tmpdir}${file.separator}dataflow-tests${file.separator}input",
-			"fixedDelay = 100", "timeUnit = MILLISECONDS", "mode = ref", "filenamePattern = *.txt"})
+	@IntegrationTest({"file.directory = ${java.io.tmpdir}${file.separator}dataflow-tests${file.separator}input",
+			"trigger.fixedDelay = 100", "trigger.timeUnit = MILLISECONDS", "file.consumer.mode = ref",
+			"file.filenamePattern = *.txt"})
 	public static class FilePayloadWithPatternTests extends FileSourceTests {
 
 		@Test
@@ -212,7 +214,8 @@ public abstract class FileSourceTests {
 	}
 
 	@IntegrationTest({"file.directory = ${java.io.tmpdir}${file.separator}dataflow-tests${file.separator}input",
-			"trigger.fixedDelay = 100", "trigger.timeUnit = MILLISECONDS", "file.consumer.mode = ref", "file.filenameRegex = .*.txt"})
+			"trigger.fixedDelay = 100", "trigger.timeUnit = MILLISECONDS", "file.consumer.mode = ref",
+			"file.filenameRegex = .*.txt"})
 	public static class FilePayloadWithRegexTests extends FileSourceTests {
 
 		@Test

--- a/file/spring-cloud-starter-stream-source-file/src/test/java/org/springframework/cloud/stream/app/file/source/FileSourceTests.java
+++ b/file/spring-cloud-starter-stream-source-file/src/test/java/org/springframework/cloud/stream/app/file/source/FileSourceTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,12 +27,13 @@ import org.springframework.boot.test.SpringApplicationConfiguration;
 import org.springframework.cloud.stream.messaging.Source;
 import org.springframework.cloud.stream.test.binder.MessageCollector;
 import org.springframework.integration.file.splitter.FileSplitter;
+import org.springframework.integration.json.JsonPathUtils;
+import org.springframework.integration.support.json.JsonObjectMapperProvider;
 import org.springframework.messaging.Message;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
@@ -41,6 +42,7 @@ import static org.junit.Assert.*;
 
 /**
  * @author Gary Russell
+ * @author Artem Bilan
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringApplicationConfiguration(classes = FileSourceTests.FileSourceApplication.class)
@@ -58,7 +60,7 @@ public abstract class FileSourceTests {
 	@Autowired
 	protected MessageCollector messageCollector;
 
-	protected File atomicFileCreate(String filename) throws FileNotFoundException, IOException {
+	protected File atomicFileCreate(String filename) throws IOException {
 		File file = new File(ROOT_DIR, filename + ".tmp");
 		File fileFinal = new File(ROOT_DIR, filename);
 		file.delete();
@@ -152,8 +154,45 @@ public abstract class FileSourceTests {
 
 	}
 
-	@IntegrationTest({"file.directory = ${java.io.tmpdir}${file.separator}dataflow-tests${file.separator}input",
-			"trigger.fixedDelay = 100", "trigger.timeUnit = MILLISECONDS", "file.consumer.mode = ref", "file.filenamePattern = *.txt"})
+	@IntegrationTest({"directory = ${java.io.tmpdir}${file.separator}dataflow-tests${file.separator}input",
+			"fixedDelay = 100", "timeUnit = MILLISECONDS", "mode = lines", "withMarkers = true",
+			"markersJson = true"})
+	public static class LinesAndMarkersAsJsonPayloadTests extends FileSourceTests {
+
+		@Test
+		public void testSimpleFile() throws Exception {
+			File file = atomicFileCreate("test.txt");
+			Message<?> received = messageCollector.forChannel(source.output()).poll(10, TimeUnit.SECONDS);
+			assertNotNull(received);
+			assertThat(received.getPayload(), Matchers.instanceOf(String.class));
+			assertEquals(FileSplitter.FileMarker.Mark.START.name(),
+					JsonPathUtils.evaluate(received.getPayload(), "$.mark"));
+			received = messageCollector.forChannel(source.output()).poll(10, TimeUnit.SECONDS);
+			assertNotNull(received);
+			assertThat(received.getPayload(), Matchers.instanceOf(String.class));
+			assertEquals("this is a test", received.getPayload());
+			received = messageCollector.forChannel(source.output()).poll(10, TimeUnit.SECONDS);
+			assertNotNull(received);
+			assertThat(received.getPayload(), Matchers.instanceOf(String.class));
+			assertEquals("line2", received.getPayload());
+			received = messageCollector.forChannel(source.output()).poll(10, TimeUnit.SECONDS);
+			assertNotNull(received);
+			Object fileMarker = received.getPayload();
+			assertThat(fileMarker, Matchers.instanceOf(String.class));
+			assertEquals(FileSplitter.FileMarker.Mark.END.name(), JsonPathUtils.evaluate(fileMarker, "$.mark"));
+			FileSplitter.FileMarker fileMarker1 = JsonObjectMapperProvider.newInstance()
+					.fromJson(fileMarker, FileSplitter.FileMarker.class);
+			assertEquals(FileSplitter.FileMarker.Mark.END, fileMarker1.getMark());
+			assertEquals(file.getAbsolutePath(), fileMarker1.getFilePath());
+			assertEquals(2, fileMarker1.getLineCount());
+			file.delete();
+		}
+
+	}
+
+
+	@IntegrationTest({"directory = ${java.io.tmpdir}${file.separator}dataflow-tests${file.separator}input",
+			"fixedDelay = 100", "timeUnit = MILLISECONDS", "mode = ref", "filenamePattern = *.txt"})
 	public static class FilePayloadWithPatternTests extends FileSourceTests {
 
 		@Test

--- a/file/spring-cloud-starter-stream-source-file/src/test/java/org/springframework/cloud/stream/app/file/source/FileSourceTests.java
+++ b/file/spring-cloud-starter-stream-source-file/src/test/java/org/springframework/cloud/stream/app/file/source/FileSourceTests.java
@@ -128,7 +128,7 @@ public abstract class FileSourceTests {
 
 	@IntegrationTest({"file.directory = ${java.io.tmpdir}${file.separator}dataflow-tests${file.separator}input",
 			"trigger.fixedDelay = 100", "trigger.timeUnit = MILLISECONDS", "file.consumer.mode = lines",
-			"file.consumer.withMarkers = true"})
+			"file.consumer.withMarkers = true", "file.consumer.markersJson = false"})
 	public static class LinesAndMarkersPayloadTests extends FileSourceTests {
 
 		@Test
@@ -157,7 +157,7 @@ public abstract class FileSourceTests {
 
 	@IntegrationTest({"file.directory = ${java.io.tmpdir}${file.separator}dataflow-tests${file.separator}input",
 			"trigger.fixedDelay = 100", "trigger.timeUnit = MILLISECONDS", "file.consumer.mode = lines",
-			"file.consumer.withMarkers = true", "file.consumer.markersJson = true"})
+			"file.consumer.withMarkers = true"})
 	public static class LinesAndMarkersAsJsonPayloadTests extends FileSourceTests {
 
 		@Test

--- a/ftp/spring-cloud-starter-stream-source-ftp/README.adoc
+++ b/ftp/spring-cloud-starter-stream-source-ftp/README.adoc
@@ -37,6 +37,7 @@ $$timeUnit$$:: $$the time unit for the fixed and initial delays$$ *($$String$$, 
 $$tmpFileSuffix$$:: $$extension to use when downloading files$$ *($$String$$, default: `.tmp`)*
 $$username$$:: $$the username for the FTP connection$$ *($$String$$, no default)*
 $$withMarkers$$:: $$if true emits start of file/end of file marker messages before/after the data. Only valid with FileReadingMode 'lines'$$ *($$Boolean$$, no default)*
+$$markersJson$$:: $$if `true` emits file markers as JSON String. Only applied when FileReadingMode is 'lines'$$ *($$boolean$$, default: `true`)*
 
 //end::ref-doc[]
 == Build

--- a/processor/spring-cloud-starter-stream-processor-splitter/README.adoc
+++ b/processor/spring-cloud-starter-stream-processor-splitter/README.adoc
@@ -7,6 +7,7 @@ message into several distinct messages.
 $$expression$$:: $$a SpEL expression which would typically evaluate to an array or collection$$ *($$String$$, default: `null`)*
 $$delimiters$$:: $$A list of delimiters to tokenize a String payload ('expression' must be null)$$ *($$String$$, default: `null`)*
 $$fileMarkers$$:: $$Split File payloads, when true, START and END marker messages will be emitted, when false no markers are emitted$$ *($$String$$, default: `null`)*
+$$markersJson$$:: $$If `true` emits file markers as JSON String. Only applied when `fileMarkers` is `true`$$ *($$boolean$$, default: `false`)*
 $$charset$$:: $$Split File payloads using this charset to convert bytes to String$$ *($$String$$, default: `null`)*
 $$applySequence$$:: $$Add correlation and sequence information to the message headers$$ *($$String$$, default: `true`)*
 

--- a/processor/spring-cloud-starter-stream-processor-splitter/README.adoc
+++ b/processor/spring-cloud-starter-stream-processor-splitter/README.adoc
@@ -7,7 +7,7 @@ message into several distinct messages.
 $$expression$$:: $$a SpEL expression which would typically evaluate to an array or collection$$ *($$String$$, default: `null`)*
 $$delimiters$$:: $$A list of delimiters to tokenize a String payload ('expression' must be null)$$ *($$String$$, default: `null`)*
 $$fileMarkers$$:: $$Split File payloads, when true, START and END marker messages will be emitted, when false no markers are emitted$$ *($$String$$, default: `null`)*
-$$markersJson$$:: $$If `true` emits file markers as JSON String. Only applied when `fileMarkers` is `true`$$ *($$boolean$$, default: `false`)*
+$$markersJson$$:: $$If `true` emits file markers as JSON String. Only applied when `fileMarkers` is `true`$$ *($$boolean$$, default: `true`)*
 $$charset$$:: $$Split File payloads using this charset to convert bytes to String$$ *($$String$$, default: `null`)*
 $$applySequence$$:: $$Add correlation and sequence information to the message headers$$ *($$String$$, default: `true`)*
 

--- a/processor/spring-cloud-starter-stream-processor-splitter/src/main/java/org/springframework/cloud/stream/app/splitter/processor/SplitterProcessorConfiguration.java
+++ b/processor/spring-cloud-starter-stream-processor-splitter/src/main/java/org/springframework/cloud/stream/app/splitter/processor/SplitterProcessorConfiguration.java
@@ -79,7 +79,7 @@ public class SplitterProcessorConfiguration {
 						if (markers == null) {
 							markers = false;
 						}
-						FileSplitter splitter = new FileSplitter(true, markers);
+						FileSplitter splitter = new FileSplitter(true, markers, properties.getMarkersJson());
 						if (charset != null) {
 							splitter.setCharset(Charset.forName(charset));
 						}

--- a/processor/spring-cloud-starter-stream-processor-splitter/src/main/java/org/springframework/cloud/stream/app/splitter/processor/SplitterProcessorProperties.java
+++ b/processor/spring-cloud-starter-stream-processor-splitter/src/main/java/org/springframework/cloud/stream/app/splitter/processor/SplitterProcessorProperties.java
@@ -16,15 +16,16 @@
 
 package org.springframework.cloud.stream.app.splitter.processor;
 
+import javax.validation.constraints.AssertTrue;
+
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.expression.Expression;
-
-import javax.validation.constraints.AssertTrue;
 
 /**
  * Configuration properties for the Splitter Processor app.
  *
  * @author Gary Russell
+ * @author Artem Bilan
  */
 @ConfigurationProperties("splitter")
 public class SplitterProcessorProperties {
@@ -48,6 +49,13 @@ public class SplitterProcessorProperties {
 	private Boolean fileMarkers;
 
 	/**
+	 * When {@code fileMarkers == true}, specify if they should be produced
+	 * as {@link org.springframework.integration.file.splitter.FileSplitter.FileMarker}
+	 * objects or JSON.
+	 */
+	private boolean markersJson = false;
+
+	/**
 	 * The charset to use when converting bytes in text-based files
 	 * to String.
 	 */
@@ -64,11 +72,11 @@ public class SplitterProcessorProperties {
 	}
 
 	public Expression getExpression() {
-		return expression;
+		return this.expression;
 	}
 
 	public String getDelimiters() {
-		return delimiters;
+		return this.delimiters;
 	}
 
 	public void setDelimiters(String delimiters) {
@@ -76,15 +84,23 @@ public class SplitterProcessorProperties {
 	}
 
 	public Boolean getFileMarkers() {
-		return fileMarkers;
+		return this.fileMarkers;
 	}
 
 	public void setFileMarkers(Boolean fileMarkers) {
 		this.fileMarkers = fileMarkers;
 	}
 
+	public boolean getMarkersJson() {
+		return this.markersJson;
+	}
+
+	public void setMarkersJson(boolean markersJson) {
+		this.markersJson = markersJson;
+	}
+
 	public String getCharset() {
-		return charset;
+		return this.charset;
 	}
 
 	public void setCharset(String charset) {
@@ -92,7 +108,7 @@ public class SplitterProcessorProperties {
 	}
 
 	public boolean isApplySequence() {
-		return applySequence;
+		return this.applySequence;
 	}
 
 	public void setApplySequence(boolean applySequence) {

--- a/processor/spring-cloud-starter-stream-processor-splitter/src/main/java/org/springframework/cloud/stream/app/splitter/processor/SplitterProcessorProperties.java
+++ b/processor/spring-cloud-starter-stream-processor-splitter/src/main/java/org/springframework/cloud/stream/app/splitter/processor/SplitterProcessorProperties.java
@@ -49,11 +49,10 @@ public class SplitterProcessorProperties {
 	private Boolean fileMarkers;
 
 	/**
-	 * When {@code fileMarkers == true}, specify if they should be produced
-	 * as {@link org.springframework.integration.file.splitter.FileSplitter.FileMarker}
-	 * objects or JSON.
+	 * When 'fileMarkers == true', specify if they should be produced
+	 * as FileSplitter.FileMarker objects or JSON.
 	 */
-	private boolean markersJson = false;
+	private boolean markersJson = true;
 
 	/**
 	 * The charset to use when converting bytes in text-based files

--- a/processor/spring-cloud-starter-stream-processor-splitter/src/test/java/org/springframework/cloud/stream/app/splitter/processor/SplitterProcessorIntegrationTests.java
+++ b/processor/spring-cloud-starter-stream-processor-splitter/src/test/java/org/springframework/cloud/stream/app/splitter/processor/SplitterProcessorIntegrationTests.java
@@ -58,10 +58,11 @@ import static org.springframework.integration.test.matcher.PayloadMatcher.hasPay
 /**
  * Integration Tests for the Splitter Processor.
  *
+ * @author Gary Russell
+ * @author Artem Bilan
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringApplicationConfiguration(classes = SplitterProcessorIntegrationTests.SplitterProcessorApplication.class)
-@WebIntegrationTest(randomPort = true)
 @DirtiesContext
 public abstract class SplitterProcessorIntegrationTests {
 
@@ -95,7 +96,7 @@ public abstract class SplitterProcessorIntegrationTests {
 	}
 
 	@IntegrationTest("splitter.delimiters = ,")
-	public static class withDelimitersTests extends SplitterProcessorIntegrationTests {
+	public static class WithDelimitersTests extends SplitterProcessorIntegrationTests {
 
 		@Test
 		public void test() {
@@ -108,7 +109,7 @@ public abstract class SplitterProcessorIntegrationTests {
 	}
 
 	@IntegrationTest({ "splitter.fileMarkers = false", "splitter.charset = UTF-8", "splitter.applySequence = false" })
-	public static class fromFileTests extends SplitterProcessorIntegrationTests {
+	public static class FromFileTests extends SplitterProcessorIntegrationTests {
 
 		@Test
 		public void test() throws Exception {
@@ -128,8 +129,8 @@ public abstract class SplitterProcessorIntegrationTests {
 		}
 	}
 
-	@IntegrationTest({ "splitter.fileMarkers = true", "splitter.charset = UTF-8" })
-	public static class fromFileWithMarkersTests extends SplitterProcessorIntegrationTests {
+	@IntegrationTest({ "splitter.fileMarkers = true", "splitter.charset = UTF-8", "splitter.markersJson = false" })
+	public static class FromFileWithMarkersTests extends SplitterProcessorIntegrationTests {
 
 		@Test
 		public void test() throws Exception {

--- a/sftp/spring-cloud-starter-stream-source-sftp/README.adoc
+++ b/sftp/spring-cloud-starter-stream-source-sftp/README.adoc
@@ -40,6 +40,7 @@ $$timeUnit$$:: $$the time unit for the fixed and initial delays$$ *($$String$$, 
 $$tmpFileSuffix$$:: $$extension to use when downloading files$$ *($$String$$, default: `.tmp`)*
 $$user$$:: $$the username to use$$ *($$String$$, no default)*
 $$withMarkers$$:: $$if true emits start of file/end of file marker messages before/after the data. Only valid with FileReadingMode 'lines'$$ *($$Boolean$$, no default)*
+$$markersJson$$:: $$if `true` emits file markers as JSON String. Only applied when FileReadingMode is 'lines'$$ *($$boolean$$, default: `true`)*
 
 //end::ref-doc[]
 == Build

--- a/spring-cloud-stream-app-dependencies/pom.xml
+++ b/spring-cloud-stream-app-dependencies/pom.xml
@@ -21,7 +21,7 @@
 		<spring-cloud-stream.version>1.0.0.RELEASE</spring-cloud-stream.version>
 		<spring-data-hadoop.version>2.4.0.M1</spring-data-hadoop.version>
 		<cloudfoundry-client-lib.version>1.1.3</cloudfoundry-client-lib.version>
-		<spring-integration.version>4.2.5.RELEASE</spring-integration.version>
+		<spring-integration.version>4.2.8.RELEASE</spring-integration.version>
 		<spring-integration-java-dsl.version>1.1.2.RELEASE</spring-integration-java-dsl.version>
 		<reactor.version>2.0.8.RELEASE</reactor.version>
 		<codahale.version>3.0.2</codahale.version>


### PR DESCRIPTION
- Upgrade to `SI-4.2.8` (4.2.7 is with bug for unexpected Reactor dependency)
- Add `markersJson` to those apps where `FileSplitter` is in use
