### PR TITLE
Cassandra Sink: Add prefix for properties

### DIFF
--- a/cassandra/spring-cloud-starter-stream-sink-cassandra/README.adoc
+++ b/cassandra/spring-cloud-starter-stream-sink-cassandra/README.adoc
@@ -1,28 +1,29 @@
 //tag::ref-doc[]
-= Cassandra Sink 
+= Cassandra Sink
 
-This module writes the content of each message it receives to Cassandra.
+This sink application writes the content of each message it receives into Cassandra.
 
 == Options
 
 The **$$cassandra$$** $$sink$$ has the following options:
 
-$$compressionType$$:: $$the compression to use for the transport$$ *($$CompressionType$$, default: `NONE`, possible values: `NONE,SNAPPY`)*
-$$consistencyLevel$$:: $$the consistencyLevel option of WriteOptions$$ *($$ConsistencyLevel$$, no default, possible values: `ANY,ONE,TWO,THREE,QUOROM,LOCAL_QUOROM,EACH_QUOROM,ALL,LOCAL_ONE,SERIAL,LOCAL_SERIAL`)*
-$$spring.cassandra.contactPoints$$:: $$the comma-delimited string of the hosts to connect to Cassandra$$ *($$String$$, default: `localhost`)*
-$$entityBasePackages$$:: $$the base packages to scan for entities annotated with Table annotations$$ *($$String[]$$, default: `[]`)*
 $$ingestQuery$$:: $$the ingest Cassandra query$$ *($$String$$, no default)*
-$$spring.cassandra.initScript$$:: $$the path to file with CQL scripts (delimited by ';') to initialize keyspace schema$$ *($$String$$, no default)*
-$$spring.cassandra.keyspace$$:: $$the keyspace name to connect to$$ *($$String$$, default: `<stream name>`)*
-$$metricsEnabled$$:: $$enable/disable metrics collection for the created cluster$$ *($$boolean$$, default: `true`)*
-$$spring.cassandra.password$$:: $$the password for connection$$ *($$String$$, no default)*
-$$spring.cassandra.port$$:: $$the port to use to connect to the Cassandra host$$ *($$int$$, default: `9042`)*
 $$queryType$$:: $$the queryType for Cassandra Sink$$ *($$Type$$, default: `INSERT`, possible values: `INSERT,UPDATE,DELETE,STATEMENT`)*
-$$retryPolicy$$:: $$the retryPolicy  option of WriteOptions$$ *($$RetryPolicy$$, no default, possible values: `DEFAULT,DOWNGRADING_CONSISTENCY,FALLTHROUGH,LOGGING`)*
 $$statementExpression$$:: $$the expression in Cassandra query DSL style$$ *($$String$$, no default)*
-$$spring.cassandra.schemaAction$$:: $$schema action to perform$$ *($$SchemaAction$$, default: `NONE`, possible values: `CREATE,NONE,RECREATE,RECREATE_DROP_UNUSED`)*
+$$consistencyLevel$$:: $$the consistencyLevel option of WriteOptions$$ *($$ConsistencyLevel$$, no default, possible values: `ANY,ONE,TWO,THREE,QUOROM,LOCAL_QUOROM,EACH_QUOROM,ALL,LOCAL_ONE,SERIAL,LOCAL_SERIAL`)*
+$$retryPolicy$$:: $$the retryPolicy  option of WriteOptions$$ *($$RetryPolicy$$, no default, possible values: `DEFAULT,DOWNGRADING_CONSISTENCY,FALLTHROUGH,LOGGING`)*
 $$ttl$$:: $$the time-to-live option of WriteOptions$$ *($$int$$, default: `0`)*
-$$spring.cassandra.username$$:: $$the username for connection$$ *($$String$$, no default)*
+$$cassandra.cluster.contactPoints$$:: $$the comma-delimited string of the hosts to connect to Cassandra$$ *($$String$$, default: `localhost`)*
+$$cassandra.cluster.port$$:: $$the port to use to connect to the Cassandra host$$ *($$int$$, default: `9042`)*
+$$cassandra.cluster.keyspace$$:: $$the keyspace name to connect to$$ *($$String$$, default: `<stream name>`)*
+$$cassandra.cluster.username$$:: $$the username for connection$$ *($$String$$, no default)*
+$$cassandra.cluster.password$$:: $$the password for connection$$ *($$String$$, no default)*
+$$cassandra.cluster.initScript$$:: $$the path to file with CQL scripts (delimited by ';') to initialize keyspace schema$$ *($$String$$, no default)*
+$$cassandra.cluster.schemaAction$$:: $$schema action to perform$$ *($$SchemaAction$$, default: `NONE`, possible values: `CREATE,NONE,RECREATE,RECREATE_DROP_UNUSED`)*
+$$cassandra.cluster.createKeyspace$$:: $$The flag to create (or not) keyspace on application startup$$ *($$Boolean$$, default: `false`)*
+$$cassandra.cluster.entityBasePackages$$:: $$the base packages to scan for entities annotated with Table annotations$$ *($$String[]$$, default: `[]`)*
+$$cassandra.cluster.compressionType$$:: $$the compression to use for the transport$$ *($$CompressionType$$, default: `NONE`, possible values: `NONE,SNAPPY`)*
+$$cassandra.cluster.metricsEnabled$$:: $$enable/disable metrics collection for the created cluster$$ *($$boolean$$, default: `true`)*
 
 //end::ref-doc[]
 

--- a/cassandra/spring-cloud-starter-stream-sink-cassandra/src/main/java/org/springframework/cloud/stream/app/cassandra/CassandraProperties.java
+++ b/cassandra/spring-cloud-starter-stream-sink-cassandra/src/main/java/org/springframework/cloud/stream/app/cassandra/CassandraProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,11 @@
 
 package org.springframework.cloud.stream.app.cassandra;
 
+import javax.validation.constraints.AssertFalse;
+import javax.validation.constraints.NotNull;
+
 import org.hibernate.validator.constraints.Range;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.cassandra.config.CassandraCqlClusterFactoryBean;
@@ -25,16 +29,13 @@ import org.springframework.core.io.Resource;
 import org.springframework.data.cassandra.config.SchemaAction;
 import org.springframework.util.StringUtils;
 
-import javax.validation.constraints.AssertFalse;
-import javax.validation.constraints.NotNull;
-
 /**
  * Common properties for the cassandra modules.
  *
  * @author Artem Bilan
  * @author Thomas Risberg
  */
-@ConfigurationProperties("spring.cassandra")
+@ConfigurationProperties("cassandra.cluster")
 public class CassandraProperties {
 
 	/**
@@ -54,7 +55,7 @@ public class CassandraProperties {
 	private String keyspace;
 
 	/**
-	 * The flag to create (or not) keyspace on module startup.
+	 * The flag to create (or not) keyspace on application startup.
 	 */
 	private boolean createKeyspace;
 

--- a/cassandra/spring-cloud-starter-stream-sink-cassandra/src/main/java/org/springframework/cloud/stream/app/cassandra/sink/CassandraSinkConfiguration.java
+++ b/cassandra/spring-cloud-starter-stream-sink-cassandra/src/main/java/org/springframework/cloud/stream/app/cassandra/sink/CassandraSinkConfiguration.java
@@ -16,20 +16,24 @@
 
 package org.springframework.cloud.stream.app.cassandra.sink;
 
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.util.StdDateFormat;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cassandra.core.WriteOptions;
 import org.springframework.cloud.stream.annotation.EnableBinding;
 import org.springframework.cloud.stream.app.cassandra.CassandraConfiguration;
-import org.springframework.cloud.stream.config.SpelExpressionConverterConfiguration;
 import org.springframework.cloud.stream.messaging.Sink;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.PropertySource;
 import org.springframework.data.cassandra.core.CassandraOperations;
 import org.springframework.integration.annotation.ServiceActivator;
 import org.springframework.integration.cassandra.outbound.CassandraMessageHandler;
@@ -44,19 +48,19 @@ import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.MessageHandler;
 import org.springframework.util.StringUtils;
 
-import java.util.*;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.util.StdDateFormat;
 
 /**
  * @author Artem Bilan
  * @author Thomas Risberg
  * @author Ashu Gairola
  */
-@Configuration
-@Import({SpelExpressionConverterConfiguration.class, CassandraConfiguration.class})
 @EnableBinding(Sink.class)
+@Import(CassandraConfiguration.class)
 @EnableConfigurationProperties(CassandraSinkProperties.class)
+@PropertySource("cassandra-application.properties")
 public class CassandraSinkConfiguration {
 
 	@Autowired

--- a/cassandra/spring-cloud-starter-stream-sink-cassandra/src/main/java/org/springframework/cloud/stream/app/cassandra/sink/CassandraSinkProperties.java
+++ b/cassandra/spring-cloud-starter-stream-sink-cassandra/src/main/java/org/springframework/cloud/stream/app/cassandra/sink/CassandraSinkProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ import org.springframework.integration.cassandra.outbound.CassandraMessageHandle
  * @author Artem Bilan
  * @author Thomas Risberg
  */
-@ConfigurationProperties
+@ConfigurationProperties("cassandra")
 public class CassandraSinkProperties {
 
 	/**

--- a/cassandra/spring-cloud-starter-stream-sink-cassandra/src/main/resources/META-INF/spring-configuration-metadata-whitelist.properties
+++ b/cassandra/spring-cloud-starter-stream-sink-cassandra/src/main/resources/META-INF/spring-configuration-metadata-whitelist.properties
@@ -1,0 +1,2 @@
+configuration-properties.classes=org.springframework.cloud.stream.app.cassandra.CassandraProperties, \
+  org.springframework.cloud.stream.app.cassandra.sink.CassandraSinkProperties

--- a/cassandra/spring-cloud-starter-stream-sink-cassandra/src/main/resources/cassandra-application.properties
+++ b/cassandra/spring-cloud-starter-stream-sink-cassandra/src/main/resources/cassandra-application.properties
@@ -1,0 +1,2 @@
+spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.cassandra.CassandraAutoConfiguration, \
+  org.springframework.boot.autoconfigure.data.cassandra.CassandraDataAutoConfiguration

--- a/cassandra/spring-cloud-starter-stream-sink-cassandra/src/test/java/org/springframework/cloud/stream/app/cassandra/sink/CassandraSinkIntegrationTests.java
+++ b/cassandra/spring-cloud-starter-stream-sink-cassandra/src/test/java/org/springframework/cloud/stream/app/cassandra/sink/CassandraSinkIntegrationTests.java
@@ -64,8 +64,8 @@ import static org.junit.Assert.assertTrue;
 		listeners = {IntegrationTestPropertiesListener.class,
 				CassandraUnitDependencyInjectionIntegrationTestExecutionListener.class})
 @SpringApplicationConfiguration(CassandraSinkIntegrationTests.CassandraSinkApplication.class)
-@IntegrationTest({"spring.cassandra.keyspace=" + CassandraSinkIntegrationTests.CASSANDRA_KEYSPACE,
-		"spring.cassandra.createKeyspace=true",
+@IntegrationTest({"cassandra.cluster.keyspace=" + CassandraSinkIntegrationTests.CASSANDRA_KEYSPACE,
+		"cassandra.cluster.createKeyspace=true",
 		"server.port=-1"})
 @EmbeddedCassandra(configuration = EmbeddedCassandraServerHelper.CASSANDRA_RNDPORT_YML_FILE, timeout = 120000)
 @DirtiesContext
@@ -82,16 +82,16 @@ public abstract class CassandraSinkIntegrationTests {
 
 	@BeforeClass
 	public static void setUp() {
-		System.setProperty("spring.cassandra.port", "" + EmbeddedCassandraServerHelper.getNativeTransportPort());
+		System.setProperty("cassandra.cluster.port", "" + EmbeddedCassandraServerHelper.getNativeTransportPort());
 	}
 
 	@AfterClass
 	public static void cleanup() {
-		System.clearProperty("spring.cassandra.port");
+		System.clearProperty("cassandra.cluster.port");
 	}
 
-	@WebIntegrationTest({"spring.cassandra.schema-action=RECREATE",
-			"spring.cassandra.entity-base-packages=org.springframework.cloud.stream.app.cassandra.domain"})
+	@WebIntegrationTest({"cassandra.cluster.schema-action=RECREATE",
+			"cassandra.cluster.entity-base-packages=org.springframework.cloud.stream.app.cassandra.domain"})
 	@Ignore("Ignoring temporarily until the CI failure root cause is resolved")
 	public static class CassandraEntityInsertTests extends CassandraSinkIntegrationTests {
 
@@ -120,10 +120,11 @@ public abstract class CassandraSinkIntegrationTests {
 
 			this.cassandraTemplate.delete(book);
 		}
+
 	}
 
-	@WebIntegrationTest(randomPort = true, value = {"spring.cassandra.init-script=init-db.cql",
-			"ingest-query=insert into book (isbn, title, author, pages, saleDate, inStock) values (?, ?, ?, ?, ?, ?)"})
+	@WebIntegrationTest(randomPort = true, value = {"cassandra.cluster.init-script=init-db.cql",
+			"cassandra.ingest-query=insert into book (isbn, title, author, pages, saleDate, inStock) values (?, ?, ?, ?, ?, ?)"})
 	@Ignore("Ignoring temporarily until the CI failure root cause is resolved")
 	public static class CassandraSinkIngestTests extends CassandraSinkIntegrationTests {
 
@@ -153,8 +154,8 @@ public abstract class CassandraSinkIntegrationTests {
 
 	}
 
-	@WebIntegrationTest(randomPort = true, value = {"spring.cassandra.init-script=init-db.cql",
-			"ingest-query=insert into book (isbn, title, author, pages, saleDate, inStock) values (:myIsbn, :myTitle, :myAuthor, ?, ?, ?)"})
+	@WebIntegrationTest(randomPort = true, value = {"cassandra.cluster.init-script=init-db.cql",
+			"cassandra.ingest-query=insert into book (isbn, title, author, pages, saleDate, inStock) values (:myIsbn, :myTitle, :myAuthor, ?, ?, ?)"})
 	@Ignore("Ignoring temporarily until the CI failure root cause is resolved")
 	public static class CassandraSinkIngestNamedParamsTests extends CassandraSinkIntegrationTests {
 
@@ -226,6 +227,7 @@ public abstract class CassandraSinkIntegrationTests {
 		public static void main(String[] args) {
 			SpringApplication.run(CassandraSinkApplication.class, args);
 		}
+
 	}
 
 }

--- a/cassandra/spring-cloud-starter-stream-sink-cassandra/src/test/java/org/springframework/cloud/stream/app/cassandra/sink/CassandraSinkPropertiesTests.java
+++ b/cassandra/spring-cloud-starter-stream-sink-cassandra/src/test/java/org/springframework/cloud/stream/app/cassandra/sink/CassandraSinkPropertiesTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2016 the original author or authors.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -15,7 +15,11 @@
 
 package org.springframework.cloud.stream.app.cassandra.sink;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
 import org.junit.Test;
+
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.EnvironmentTestUtils;
 import org.springframework.cassandra.core.ConsistencyLevel;
@@ -27,20 +31,17 @@ import org.springframework.context.annotation.Import;
 import org.springframework.expression.Expression;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
 import org.springframework.integration.cassandra.outbound.CassandraMessageHandler;
-import org.springframework.integration.config.EnableIntegration;
-
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * @author Thomas Risberg
+ * @author Artem Bilan
  */
 public class CassandraSinkPropertiesTests {
 
 	@Test
 	public void consistencyLevelCanBeCustomized() {
 		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
-		EnvironmentTestUtils.addEnvironment(context, "consistency-level:" + ConsistencyLevel.LOCAL_QUOROM);
+		EnvironmentTestUtils.addEnvironment(context, "CASSANDRA_CONSISTENCY_LEVEL:" + ConsistencyLevel.LOCAL_QUOROM);
 		context.register(Conf.class);
 		context.refresh();
 		CassandraSinkProperties properties = context.getBean(CassandraSinkProperties.class);
@@ -51,7 +52,7 @@ public class CassandraSinkPropertiesTests {
 	@Test
 	public void retryPolicyCanBeCustomized() {
 		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
-		EnvironmentTestUtils.addEnvironment(context, "retry-policy:" + RetryPolicy.DOWNGRADING_CONSISTENCY);
+		EnvironmentTestUtils.addEnvironment(context, "cassandra.retry-policy:" + RetryPolicy.DOWNGRADING_CONSISTENCY);
 		context.register(Conf.class);
 		context.refresh();
 		CassandraSinkProperties properties = context.getBean(CassandraSinkProperties.class);
@@ -62,7 +63,7 @@ public class CassandraSinkPropertiesTests {
 	@Test
 	public void ttlCanBeCustomized() {
 		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
-		EnvironmentTestUtils.addEnvironment(context, "ttl:" + 1000);
+		EnvironmentTestUtils.addEnvironment(context, "cassandra.ttl:" + 1000);
 		context.register(Conf.class);
 		context.refresh();
 		CassandraSinkProperties properties = context.getBean(CassandraSinkProperties.class);
@@ -73,7 +74,7 @@ public class CassandraSinkPropertiesTests {
 	@Test
 	public void queryTypeCanBeCustomized() {
 		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
-		EnvironmentTestUtils.addEnvironment(context, "query-type:" + CassandraMessageHandler.Type.UPDATE);
+		EnvironmentTestUtils.addEnvironment(context, "cassandra.query-type:" + CassandraMessageHandler.Type.UPDATE);
 		context.register(Conf.class);
 		context.refresh();
 		CassandraSinkProperties properties = context.getBean(CassandraSinkProperties.class);
@@ -85,7 +86,7 @@ public class CassandraSinkPropertiesTests {
 	public void ingestQueryCanBeCustomized() {
 		String query = "insert into book (isbn, title, author) values (?, ?, ?)";
 		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
-		EnvironmentTestUtils.addEnvironment(context, "ingest-query:" + query);
+		EnvironmentTestUtils.addEnvironment(context, "cassandra.ingest-query:" + query);
 		context.register(Conf.class);
 		context.refresh();
 		CassandraSinkProperties properties = context.getBean(CassandraSinkProperties.class);
@@ -98,7 +99,7 @@ public class CassandraSinkPropertiesTests {
 		String queryDsl = "Select(FOO.BAR).From(FOO)";
 		Expression expression =  new SpelExpressionParser().parseExpression(queryDsl);
 		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
-		EnvironmentTestUtils.addEnvironment(context, "statement-expression:" + queryDsl);
+		EnvironmentTestUtils.addEnvironment(context, "cassandra.statementExpression:" + queryDsl);
 		context.register(Conf.class);
 		context.refresh();
 		CassandraSinkProperties properties = context.getBean(CassandraSinkProperties.class);
@@ -107,7 +108,6 @@ public class CassandraSinkPropertiesTests {
 	}
 
 	@Configuration
-	@EnableIntegration
 	@EnableConfigurationProperties(CassandraSinkProperties.class)
 	@Import(SpelExpressionConverterConfiguration.class)
 	static class Conf {


### PR DESCRIPTION
- Rename prefix in common `CassandraProperties` into `cassandra.cluster`
- Add `cassandra` prefix into `CassandraSinkProperties`
- Add `spring-configuration-metadata-whitelist.properties` for Cassandra Sink
- Add `cassandra-application.properties` with `spring.autoconfigure.exclude` property to exclude Boot's auto-configs for Casssandra
- Fix `README.adoc` according these changes
