### PR TITLE
Updating project to latest release version of task

### DIFF
--- a/spring-cloud-stream-app-dependencies/pom.xml
+++ b/spring-cloud-stream-app-dependencies/pom.xml
@@ -30,7 +30,7 @@
 		<pmml.version>1.2.6</pmml.version>
 		<spring-cloud-deployer-spi.version>1.0.0.RC1</spring-cloud-deployer-spi.version>
 		<spring-cloud-deployer-local.version>1.0.0.RC1</spring-cloud-deployer-local.version>
-		<spring.cloud.task.version>1.0.0.RC1</spring.cloud.task.version>
+		<spring.cloud.task.version>1.0.1.RELEASE</spring.cloud.task.version>
 		<spring.cloud.dependencies.version>Brixton.SR1</spring.cloud.dependencies.version>
 		<spring-analytics.version>1.0.0.RC1</spring-analytics.version>
 	</properties>

--- a/tasklauncher/spring-cloud-starter-stream-sink-tasklauncher-local/src/test/java/org/springframework/cloud/stream/app/task/launcher/local/sink/TaskLauncherLocalSinkIntegrationTests.java
+++ b/tasklauncher/spring-cloud-starter-stream-sink-tasklauncher-local/src/test/java/org/springframework/cloud/stream/app/task/launcher/local/sink/TaskLauncherLocalSinkIntegrationTests.java
@@ -59,7 +59,7 @@ public class TaskLauncherLocalSinkIntegrationTests {
 
 	@Test(expected = MessageHandlingException.class)
 	public void sendBadRequest() throws IOException {
-		TaskLaunchRequest request = new TaskLaunchRequest("maven://foo", null, null);
+		TaskLaunchRequest request = new TaskLaunchRequest("maven://foo", null, null, null);
 		sink.input().send(new GenericMessage<>(request));
 	}
 
@@ -68,7 +68,7 @@ public class TaskLauncherLocalSinkIntegrationTests {
 		TaskSinkConfiguration.TestTaskLauncher testTaskLauncher =
 				(TaskSinkConfiguration.TestTaskLauncher) applicationContext.getBean(TaskSinkConfiguration.TestTaskLauncher.class);
 
-		TaskLaunchRequest request = new TaskLaunchRequest("maven://org.springframework.cloud.task.app:timestamp-task:jar:1.0.0.BUILD-SNAPSHOT", null, null);
+		TaskLaunchRequest request = new TaskLaunchRequest("maven://org.springframework.cloud.task.app:timestamp-task:jar:1.0.0.BUILD-SNAPSHOT", null, null, null);
 		sink.input().send(new GenericMessage<>(request));
 		assertEquals(LaunchState.complete, testTaskLauncher.status("TESTSTATUS").getState());
 	}

--- a/triggertask/spring-cloud-starter-stream-source-triggertask/src/main/java/org/springframework/cloud/stream/app/triggertask/source/TaskPayloadProperties.java
+++ b/triggertask/spring-cloud-starter-stream-source-triggertask/src/main/java/org/springframework/cloud/stream/app/triggertask/source/TaskPayloadProperties.java
@@ -41,9 +41,14 @@ public class TaskPayloadProperties {
 	private String uri = "";
 
 	/**
-	 * Comma delimited key=value pairs to be used as properties for the task.
+	 * Comma delimited key=value pairs to be used as environmentProperties for the task.
 	 */
-	private String properties = "";
+	private String environmentProperties = "";
+
+	/**
+	 * Comma delimited key=value pairs to be used as deploymentProperties for the task.
+	 */
+	private String deploymentProperties = "";
 
 	public String getCommandLineArgs() {
 		return commandLineArgs;
@@ -63,12 +68,22 @@ public class TaskPayloadProperties {
 		this.uri = uri;
 	}
 
-	public String getProperties() {
-		return properties;
+	public String getEnvironmentProperties() {
+		return environmentProperties;
 	}
 
-	public void setProperties(String properties) {
-		Assert.notNull("properties must not be null");
-		this.properties = properties;
+	public void setEnvironmentProperties(String environmentProperties) {
+		Assert.notNull(environmentProperties, "environmentProperties must not be null");
+		this.environmentProperties = environmentProperties;
 	}
+
+	public String getDeploymentProperties() {
+		return deploymentProperties;
+	}
+
+	public void setDeploymentProperties(String deploymentProperties) {
+		Assert.notNull(deploymentProperties, "deploymentProperties must not be null");
+		this.deploymentProperties = deploymentProperties;
+	}
+
 }

--- a/triggertask/spring-cloud-starter-stream-source-triggertask/src/main/java/org/springframework/cloud/stream/app/triggertask/source/TaskPayloadProperties.java
+++ b/triggertask/spring-cloud-starter-stream-source-triggertask/src/main/java/org/springframework/cloud/stream/app/triggertask/source/TaskPayloadProperties.java
@@ -55,7 +55,6 @@ public class TaskPayloadProperties {
 	}
 
 	public void setCommandLineArgs(String commandLineArgs) {
-		Assert.notNull("commandLineArgs must not be null");
 		this.commandLineArgs = commandLineArgs;
 	}
 
@@ -73,7 +72,6 @@ public class TaskPayloadProperties {
 	}
 
 	public void setEnvironmentProperties(String environmentProperties) {
-		Assert.notNull(environmentProperties, "environmentProperties must not be null");
 		this.environmentProperties = environmentProperties;
 	}
 
@@ -82,7 +80,6 @@ public class TaskPayloadProperties {
 	}
 
 	public void setDeploymentProperties(String deploymentProperties) {
-		Assert.notNull(deploymentProperties, "deploymentProperties must not be null");
 		this.deploymentProperties = deploymentProperties;
 	}
 

--- a/triggertask/spring-cloud-starter-stream-source-triggertask/src/main/java/org/springframework/cloud/stream/app/triggertask/source/TriggertaskSourceConfiguration.java
+++ b/triggertask/spring-cloud-starter-stream-source-triggertask/src/main/java/org/springframework/cloud/stream/app/triggertask/source/TriggertaskSourceConfiguration.java
@@ -72,7 +72,8 @@ public class TriggertaskSourceConfiguration {
 				parseParams(
 						commandLineArgumentTransformer.transform(
 								taskPayloadProperties.getCommandLineArgs())),
-				parseProperties(taskPayloadProperties.getProperties()));
+				parseProperties(taskPayloadProperties.getEnvironmentProperties()),
+				parseProperties(taskPayloadProperties.getDeploymentProperties()));
 	}
 
 	/**


### PR DESCRIPTION
The changes for triggertask were required because of the introduction of deployment properties and the renaming of properties to environmentProperties in the TaskLaunchRequest.
