### PR TITLE
Add TaskLauncherYarnSink

### DIFF
--- a/spring-cloud-stream-app-dependencies/pom.xml
+++ b/spring-cloud-stream-app-dependencies/pom.xml
@@ -29,6 +29,7 @@
 		<pmml.version>1.2.6</pmml.version>
 		<spring-cloud-deployer-spi.version>1.0.2.RELEASE</spring-cloud-deployer-spi.version>
 		<spring-cloud-deployer-local.version>1.0.2.RELEASE</spring-cloud-deployer-local.version>
+		<spring-cloud-deployer-yarn.version>1.0.1.RELEASE</spring-cloud-deployer-yarn.version>
 		<spring.cloud.task.version>1.0.1.RELEASE</spring.cloud.task.version>
 		<spring.cloud.dependencies.version>Brixton.SR3</spring.cloud.dependencies.version>
 		<spring-analytics.version>1.0.0.RELEASE</spring-analytics.version>
@@ -257,6 +258,11 @@
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.cloud.stream.app</groupId>
+				<artifactId>spring-cloud-starter-stream-sink-task-launcher-yarn</artifactId>
+				<version>1.0.3.BUILD-SNAPSHOT</version>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.cloud.stream.app</groupId>
 				<artifactId>spring-cloud-starter-stream-sink-tcp</artifactId>
 				<version>1.0.3.BUILD-SNAPSHOT</version>
 			</dependency>
@@ -447,6 +453,11 @@
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-deployer-local</artifactId>
 				<version>${spring-cloud-deployer-spi.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.cloud</groupId>
+				<artifactId>spring-cloud-starter-deployer-yarn</artifactId>
+				<version>${spring-cloud-deployer-yarn.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>

--- a/spring-cloud-stream-app-generator/pom.xml
+++ b/spring-cloud-stream-app-generator/pom.xml
@@ -147,6 +147,7 @@
 							<extraTestConfigClass>org.springframework.cloud.stream.app.test.ip.IpSourceTestConfiguration.class</extraTestConfigClass>
 						</syslog-source>
 						<task-launcher-local-sink />
+						<task-launcher-yarn-sink />
 						<tcp-sink>
 							<extraTestConfigClass>org.springframework.cloud.stream.app.test.ip.IpSinkTestConfiguration.class</extraTestConfigClass>
 						</tcp-sink>

--- a/tasklauncher/spring-cloud-starter-stream-sink-tasklauncher-yarn/README.adoc
+++ b/tasklauncher/spring-cloud-starter-stream-sink-tasklauncher-yarn/README.adoc
@@ -1,0 +1,28 @@
+//tag::ref-doc[]
+= TaskLauncher YARN Sink
+
+This application launches the task application specified in the uri attribute of the `TaskLaunchRequest` contained
+in the message that is received.
+
+Any message that does not contain a `TaskLaunchRequest` will log an error.
+
+== Using the TaskLauncher
+A tasklauncher is a sink that consumes a `TaskLaunchRequest` message, deploys and launches a task using a Spring
+Cloud Deployer.  The task will use the --uri from the message to determine what artifact to deploy as well as the
+properties and arguments to execute the task.  An example of this using Spring Cloud Data Flow would look like this:
+
+`stream create foo --definition "triggertask --uri=maven://org.springframework.cloud.task.app:timestamp-task:jar:1.0.0.BUILD-SNAPSHOT --fixed-delay=5 | tasklauncher-yarn"`
+
+Another example would be to use a processor to translate a message from another source into a `TaskLaunchRequest` that
+would be sent to the tasklauncher sink.
+
+== Limitations
+Currently `tasklauncher-yarn` sink only works on Dataflow for Apache Yarn and yarn deployer version in this sink has to match same version used in a dataflow server.
+
+//end::ref-doc[]
+
+== Build
+
+```
+$ mvn clean package
+```

--- a/tasklauncher/spring-cloud-starter-stream-sink-tasklauncher-yarn/pom.xml
+++ b/tasklauncher/spring-cloud-starter-stream-sink-tasklauncher-yarn/pom.xml
@@ -13,20 +13,27 @@
   ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
-  --><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<artifactId>spring-cloud-stream-tasklauncher-parent</artifactId>
-	<packaging>pom</packaging>
 
 	<parent>
 		<groupId>org.springframework.cloud.stream.app</groupId>
-		<artifactId>spring-cloud-stream-app-starters</artifactId>
+		<artifactId>spring-cloud-stream-tasklauncher-parent</artifactId>
 		<version>1.0.3.BUILD-SNAPSHOT</version>
 	</parent>
 
-	<modules>
-		<module>spring-cloud-starter-stream-sink-tasklauncher-local</module>
-		<module>spring-cloud-starter-stream-sink-tasklauncher-yarn</module>
-	</modules>
+	<artifactId>spring-cloud-starter-stream-sink-task-launcher-yarn</artifactId>
 
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-task-stream</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-starter-deployer-yarn</artifactId>
+		</dependency>
+	</dependencies>
 </project>

--- a/tasklauncher/spring-cloud-starter-stream-sink-tasklauncher-yarn/src/main/java/org/springframework/cloud/stream/app/task/launcher/yarn/sink/TaskLauncherYarnSinkConfiguration.java
+++ b/tasklauncher/spring-cloud-starter-stream-sink-tasklauncher-yarn/src/main/java/org/springframework/cloud/stream/app/task/launcher/yarn/sink/TaskLauncherYarnSinkConfiguration.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.app.task.launcher.yarn.sink;
+
+import org.springframework.cloud.stream.annotation.EnableBinding;
+import org.springframework.cloud.stream.messaging.Sink;
+import org.springframework.cloud.task.launcher.annotation.EnableTaskLauncher;
+
+/**
+ * Configuration class for the TaskLauncherSink.
+ *
+ * @author Janne Valkealahti
+ */
+@EnableBinding(Sink.class)
+@EnableTaskLauncher
+public class TaskLauncherYarnSinkConfiguration {
+}

--- a/tasklauncher/spring-cloud-starter-stream-sink-tasklauncher-yarn/src/main/java/org/springframework/cloud/stream/app/task/launcher/yarn/sink/TaskLauncherYarnSinkProperties.java
+++ b/tasklauncher/spring-cloud-starter-stream-sink-tasklauncher-yarn/src/main/java/org/springframework/cloud/stream/app/task/launcher/yarn/sink/TaskLauncherYarnSinkProperties.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.app.task.launcher.yarn.sink;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Configuration properties for yarn task launcher sink.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+@ConfigurationProperties("tasklauncher-yarn")
+public class TaskLauncherYarnSinkProperties {
+}

--- a/tasklauncher/spring-cloud-starter-stream-sink-tasklauncher-yarn/src/main/resources/META-INF/spring-configuration-metadata-whitelist.properties
+++ b/tasklauncher/spring-cloud-starter-stream-sink-tasklauncher-yarn/src/main/resources/META-INF/spring-configuration-metadata-whitelist.properties
@@ -1,0 +1,1 @@
+configuration-properties.classes=org.springframework.cloud.stream.app.task.launcher.yarn.sink.TaskLauncherYarnSinkProperties

--- a/tasklauncher/spring-cloud-starter-stream-sink-tasklauncher-yarn/src/main/resources/META-INF/spring.provides
+++ b/tasklauncher/spring-cloud-starter-stream-sink-tasklauncher-yarn/src/main/resources/META-INF/spring.provides
@@ -1,0 +1,1 @@
+provides: spring-cloud-starter-stream-sink-task-launcher-yarn


### PR DESCRIPTION
- Add tasklauncher-yarn sink.
- Rely on yarn deployer 1.0.1.RELEASE.
- Uses empty config props for whitelisting. Better yarn deployer config
  is coming with future yarn deployer releases.
- Fixes #107

To test(with local hadoop single node):

```
#wget http://repo.spring.io/libs-staging-local/org/springframework/cloud/dist/spring-cloud-dataflow-server-yarn-dist/1.0.1.RELEASE/spring-cloud-dataflow-server-yarn-dist-1.0.1.RELEASE.zip
#unzip spring-cloud-dataflow-server-yarn-dist-1.0.1.RELEASE.zip
```

```
./spring-cloud-dataflow-server-yarn-1.0.1.RELEASE/bin/dataflow-server-yarn-cli shell
$ push -t TASK
New version installed
$ push -t STREAM
New version installed
```

```
./spring-cloud-dataflow-server-yarn-1.0.1.RELEASE/bin/dataflow-shell
dataflow:>hadoop fs copyFromLocal --from /home/jvalkealahti/repos/jvalkeal/spring-cloud-stream-app-starters/apps/task-launcher-yarn-sink-rabbit/target/task-launcher-yarn-sink-rabbit-1.0.3.BUILD-SNAPSHOT.jar --to /dataflow/repo/
dataflow:>app register --name tasklauncher-yarn --type sink --uri hdfs:/dataflow/repo/task-launcher-yarn-sink-rabbit-1.0.3.BUILD-SNAPSHOT.jar
dataflow:>app import --uri http://bit.ly/1-0-2-GA-stream-applications-rabbit-maven
dataflow:>stream create yarntasklaunchstream --definition "triggertask --uri=maven://org.springframework.cloud.task.app:timestamp-task:jar:1.0.0.BUILD-SNAPSHOT --fixed-delay=60 | tasklauncher-yarn" --deploy
```
