### PR TITLE
Add missing references to app READMEs

### DIFF
--- a/mail/spring-cloud-starter-stream-source-mail/README.adoc
+++ b/mail/spring-cloud-starter-stream-source-mail/README.adoc
@@ -1,7 +1,7 @@
 //tag::ref-doc[]
 = Mail Source
 
-A source module that listens for Emails  and emits the message body as a message payload.
+A source module that listens for Emails and emits the message body as a message payload.
 
 
 == Options

--- a/spring-cloud-stream-app-starters-docs/src/main/asciidoc/processors.adoc
+++ b/spring-cloud-stream-app-starters-docs/src/main/asciidoc/processors.adoc
@@ -28,6 +28,9 @@ include::{app-starters-root}/processor/spring-cloud-starter-stream-processor-scr
 [[spring-cloud-stream-modules-splitter]]
 include::{app-starters-root}/processor/spring-cloud-starter-stream-processor-splitter/README.adoc[tags=ref-doc]
 
+[[spring-cloud-stream-modules-tcp-client-processor]]
+include::{app-starters-root}/tcp/spring-cloud-starter-stream-processor-tcp-client/README.adoc[tags=ref-doc]
+
 [[spring-clound-stream-modules-transform-processor]]
 include::{app-starters-root}/processor/spring-cloud-starter-stream-processor-transform/README.adoc[tags=ref-doc]
 

--- a/spring-cloud-stream-app-starters-docs/src/main/asciidoc/sinks.adoc
+++ b/spring-cloud-stream-app-starters-docs/src/main/asciidoc/sinks.adoc
@@ -5,6 +5,9 @@
 :app-starters-root:  https://raw.githubusercontent.com/spring-cloud/spring-cloud-stream-app-starters/master
 
 
+[[spring-cloud-stream-modules-aggregate-counter-sink]]
+include::{app-starters-root}/metrics/spring-cloud-starter-stream-sink-aggregate-counter/README.adoc[tags=ref-doc]
+
 [[spring-cloud-stream-modules-cassandra-sink]]
 include::{app-starters-root}/cassandra/spring-cloud-starter-stream-sink-cassandra/README.adoc[tags=ref-doc]
 
@@ -29,6 +32,9 @@ include::{app-starters-root}/gpfdist/spring-cloud-starter-stream-sink-gpfdist/RE
 [[spring-cloud-stream-modules-hdfs-sink]]
 include::{app-starters-root}/hdfs/spring-cloud-starter-stream-sink-hdfs/README.adoc[tags=ref-doc]
 
+[[spring-cloud-stream-modules-hdfs-dataset-sink]]
+include::{app-starters-root}/hdfs/spring-cloud-starter-stream-sink-hdfs-dataset/README.adoc[tags=ref-doc]
+
 [[spring-cloud-stream-modules-jdbc-sink]]
 include::{app-starters-root}/jdbc/spring-cloud-starter-stream-sink-jdbc/README.adoc[tags=ref-doc]
 
@@ -44,8 +50,11 @@ include::{app-starters-root}/redis/spring-cloud-starter-stream-sink-redis/README
 [[spring-cloud-stream-modules-router-sink]]
 include::{app-starters-root}/router/spring-cloud-starter-stream-sink-router/README.adoc[tags=ref-doc]
 
-[[spring-cloud-stream-modules-s3-sink]]
-include::{app-starters-root}/s3/spring-cloud-starter-stream-sink-s3/README.adoc[tags=ref-doc]
+[[spring-cloud-stream-modules-aws-s3-sink]]
+include::{app-starters-root}/aws-s3/spring-cloud-starter-stream-sink-s3/README.adoc[tags=ref-doc]
+
+[[spring-cloud-stream-modules-sftp-sink]]
+include::{app-starters-root}/sftp/spring-cloud-starter-stream-sink-sftp/README.adoc[tags=ref-doc]
 
 [[spring-cloud-stream-modules-tcp-sink]]
 include::{app-starters-root}/tcp/spring-cloud-starter-stream-sink-tcp/README.adoc[tags=ref-doc]

--- a/spring-cloud-stream-app-starters-docs/src/main/asciidoc/sources.adoc
+++ b/spring-cloud-stream-app-starters-docs/src/main/asciidoc/sources.adoc
@@ -10,6 +10,12 @@ include::{app-starters-root}/file/spring-cloud-starter-stream-source-file/README
 [[spring-cloud-stream-modules-ftp-source]]
 include::{app-starters-root}/ftp/spring-cloud-starter-stream-source-ftp/README.adoc[tags=ref-doc]
 
+[[spring-cloud-stream-modules-gemfire-source]]
+include::{app-starters-root}/gemfire/spring-cloud-starter-stream-source-gemfire/README.adoc[tags=ref-doc]
+
+[[spring-cloud-stream-modules-gemfire-cq-source]]
+include::{app-starters-root}/gemfire/spring-cloud-starter-stream-source-gemfire-cq/README.adoc[tags=ref-doc]
+
 [[spring-cloud-stream-modules-http-source]]
 include::{app-starters-root}/http/spring-cloud-starter-stream-source-http/README.adoc[tags=ref-doc]
 
@@ -23,10 +29,10 @@ include::{app-starters-root}/jms/spring-cloud-starter-stream-source-jms/README.a
 include::{app-starters-root}/testing/spring-cloud-starter-stream-source-load-generator/README.adoc[tags=ref-doc]
 
 [[spring-cloud-stream-modules-mail-source]]
-include::{app-starters-root}/testing/spring-cloud-starter-stream-source-mail/README.adoc[tags=ref-doc]
+include::{app-starters-root}/mail/spring-cloud-starter-stream-source-mail/README.adoc[tags=ref-doc]
 
 [[spring-cloud-stream-modules-mongodb-source]]
-include::{app-starters-root}/testing/spring-cloud-starter-stream-source-mongodb/README.adoc[tags=ref-doc]
+include::{app-starters-root}/mongodb/spring-cloud-starter-stream-source-mongodb/README.adoc[tags=ref-doc]
 
 [[spring-cloud-stream-modules-rabbit-source]]
 include::{app-starters-root}/rabbit/spring-cloud-starter-stream-source-rabbit/README.adoc[tags=ref-doc]
@@ -43,11 +49,17 @@ include::{app-starters-root}/syslog/spring-cloud-starter-stream-source-syslog/RE
 [[spring-cloud-stream-modules-tcp-source]]
 include::{app-starters-root}/tcp/spring-cloud-starter-stream-source-tcp/README.adoc[tags=ref-doc]
 
+[[spring-cloud-stream-modules-tcp-client-source]]
+include::{app-starters-root}/tcp/spring-cloud-starter-stream-source-tcp-client/README.adoc[tags=ref-doc]
+
 [[spring-cloud-stream-modules-time-source]]
 include::{app-starters-root}/time/spring-cloud-starter-stream-source-time/README.adoc[tags=ref-doc]
 
 [[spring-cloud-stream-modules-trigger-source]]
 include::{app-starters-root}/trigger/spring-cloud-starter-stream-source-trigger/README.adoc[tags=ref-doc]
+
+[[spring-cloud-stream-modules-triggertask-source]]
+include::{app-starters-root}/triggertask/spring-cloud-starter-stream-source-triggertask/README.adoc[tags=ref-doc]
 
 [[spring-cloud-stream-modules-twitterstream-source]]
 include::{app-starters-root}/twitter/spring-cloud-starter-stream-source-twitterstream/README.adoc[tags=ref-doc]

--- a/triggertask/spring-cloud-starter-stream-source-triggertask/README.adoc
+++ b/triggertask/spring-cloud-starter-stream-source-triggertask/README.adoc
@@ -1,7 +1,7 @@
 //tag::ref-doc[]
 = TriggerTask Source
 
-The TriggerTask app sends a `TaskLaunchRequest` based on a fixed delay, date or cron expression.  The user is allowed
+The TriggerTask app sends a `TaskLaunchRequest` based on a fixed delay, date or cron expression. The user is allowed
 to set the command line arguments as well as the
 http://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-external-config.html[Spring Boot properties]
 that are used by the task.


### PR DESCRIPTION
This adds references to READMEs that were previously not there (and fixes some that were broken).

Note that this PR does not address the addition of missing READMEs, so maybe we want to close issue #204 only when all deps are done

Fixes spring-cloud/spring-cloud-stream-app-starters#204
