### PR TITLE
Adding parameterization for new bom/s, boot version in app generator

### DIFF
--- a/generateApps.sh
+++ b/generateApps.sh
@@ -4,5 +4,29 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 cd $DIR
 
+while [[ $# -gt 1 ]]
+do
+key="$1"
+
+case $key in
+    -b|--bomsWithHigherPrecedence)
+    PLUGIN_PARAMS="-DbomsWithHigherPrecedence=$2"
+    shift
+    ;;
+    -bt|--bootVersion)
+    PLUGIN_PARAMS="$PLUGIN_PARAMS -DbootVersion=$2"
+    shift # past argument
+    ;;
+    *)
+        # unknown option
+    ;;
+esac
+shift
+done
+
 #execute mvn plugin with app generation
-./mvnw clean install scs:generate-app -pl :spring-cloud-stream-app-generator
+if [ -n "$PLUGIN_PARAMS" ]; then
+    ./mvnw clean install scs:generate-app -pl :spring-cloud-stream-app-generator $PLUGIN_PARAMS
+else
+    ./mvnw clean install scs:generate-app -pl :spring-cloud-stream-app-generator
+fi

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 	</scm>
 
 	<properties>
-		<scs-app-maven-plugin.version>1.0.2.RELEASE</scs-app-maven-plugin.version>
+		<scs-app-maven-plugin.version>1.1.0.BUILD-SNAPSHOT</scs-app-maven-plugin.version>
 	</properties>
 
 	<modules>

--- a/spring-cloud-stream-app-generator/pom.xml
+++ b/spring-cloud-stream-app-generator/pom.xml
@@ -11,6 +11,11 @@
 	<packaging>pom</packaging>
 	<name>spring-cloud-stream-app-generator</name>
 
+	<properties>
+		<bomsWithHigherPrecedence/>
+		<bootVersion>1.3.5.RELEASE</bootVersion>
+	</properties>
+
 	<build>
 		<plugins>
 			<plugin>
@@ -19,10 +24,11 @@
 				<version>${scs-app-maven-plugin.version}</version>
 				<configuration>
 					<javaVersion>1.7</javaVersion>
-					<bootVersion>1.3.5.RELEASE</bootVersion>
+					<bootVersion>${bootVersion}</bootVersion>
 					<generatedProjectHome>${session.executionRootDirectory}/apps</generatedProjectHome>
 					<generatedProjectVersion>${project.version}</generatedProjectVersion>
 					<applicationType>stream</applicationType>
+					<bomsWithHigherPrecedence>${bomsWithHigherPrecedence}</bomsWithHigherPrecedence>
 					<bom>
 						<name>scs-bom</name>
 						<groupId>org.springframework.cloud.stream.app</groupId>


### PR DESCRIPTION
This PR needs https://github.com/spring-cloud/spring-cloud-stream-app-maven-plugin/pull/9 from the app generation maven plugin to be merged in first. 

Additional boms can be added to app generation along with a different spring boot parent using the following plugin properties:

`./mvnw clean install scs:generate-app -pl :spring-cloud-stream-app-generator -DbomsWithHigherPrecedence=org.springframework.cloud:spring-cloud-stream-dependencies:Brooklyn.M1,org.springframework.cloud:spring-cloud-dependencies:Camden.BUILD-SNAPSHOT -DbootVersion=1.4.0.RELEASE`

This will add `Brookly.M1` release train for spring cloud stream and `Camden.BUILD-SNAPSHOT` release train for spring cloud as boms to the generated maven poms. It will also use `1.4.0.RELEASE` version of spring boot as the parent for all the generated apps. 

It can also conveniently passed in along with the shell script used to generate apps:

./generateApps.sh -b org.springframework.cloud:spring-cloud-stream-dependencies:Brooklyn.M1,org.springframework.cloud:spring-cloud-dependencies:Camden.BUILD-SNAPSHOT -bt 1.4.0.RELEASE

or more wordy:

./generateApps.sh --bomsWithHigherPrecedence org.springframework.cloud:spring-cloud-stream-dependencies:Brooklyn.M1,org.springframework.cloud:spring-cloud-dependencies:Camden.BUILD-SNAPSHOT --bootVersion 1.4.0.RELEASE
