### PR TITLE
URL Cleanup

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/app-starters-common/app-starters-annotation-common/src/main/java/org/springframework/cloud/stream/app/annotation/PollableSource.java
+++ b/app-starters-common/app-starters-annotation-common/src/main/java/org/springframework/cloud/stream/app/annotation/PollableSource.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/app-starters-common/app-starters-file-common/src/main/java/org/springframework/cloud/stream/app/file/FileConsumerProperties.java
+++ b/app-starters-common/app-starters-file-common/src/main/java/org/springframework/cloud/stream/app/file/FileConsumerProperties.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/app-starters-common/app-starters-file-common/src/main/java/org/springframework/cloud/stream/app/file/FileReadingMode.java
+++ b/app-starters-common/app-starters-file-common/src/main/java/org/springframework/cloud/stream/app/file/FileReadingMode.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/app-starters-common/app-starters-file-common/src/main/java/org/springframework/cloud/stream/app/file/FileUtils.java
+++ b/app-starters-common/app-starters-file-common/src/main/java/org/springframework/cloud/stream/app/file/FileUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/app-starters-common/app-starters-file-common/src/main/java/org/springframework/cloud/stream/app/file/remote/AbstractRemoteFileProperties.java
+++ b/app-starters-common/app-starters-file-common/src/main/java/org/springframework/cloud/stream/app/file/remote/AbstractRemoteFileProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/app-starters-common/app-starters-file-common/src/main/java/org/springframework/cloud/stream/app/file/remote/AbstractRemoteFileSinkProperties.java
+++ b/app-starters-common/app-starters-file-common/src/main/java/org/springframework/cloud/stream/app/file/remote/AbstractRemoteFileSinkProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/app-starters-common/app-starters-file-common/src/main/java/org/springframework/cloud/stream/app/file/remote/AbstractRemoteFileSourceProperties.java
+++ b/app-starters-common/app-starters-file-common/src/main/java/org/springframework/cloud/stream/app/file/remote/AbstractRemoteFileSourceProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/app-starters-common/app-starters-file-common/src/main/java/org/springframework/cloud/stream/app/file/remote/AbstractRemoteServerProperties.java
+++ b/app-starters-common/app-starters-file-common/src/main/java/org/springframework/cloud/stream/app/file/remote/AbstractRemoteServerProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/app-starters-common/app-starters-ftp-common/src/main/java/org/springframework/cloud/stream/app/ftp/FtpSessionFactoryConfiguration.java
+++ b/app-starters-common/app-starters-ftp-common/src/main/java/org/springframework/cloud/stream/app/ftp/FtpSessionFactoryConfiguration.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/app-starters-common/app-starters-ftp-common/src/main/java/org/springframework/cloud/stream/app/ftp/FtpSessionFactoryProperties.java
+++ b/app-starters-common/app-starters-ftp-common/src/main/java/org/springframework/cloud/stream/app/ftp/FtpSessionFactoryProperties.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/app-starters-common/app-starters-s3-common/src/main/java/org/springframework/cloud/stream/app/s3/AmazonS3Configuration.java
+++ b/app-starters-common/app-starters-s3-common/src/main/java/org/springframework/cloud/stream/app/s3/AmazonS3Configuration.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/app-starters-common/app-starters-sftp-common/src/main/java/org/springframework/cloud/stream/app/sftp/SftpSessionFactoryConfiguration.java
+++ b/app-starters-common/app-starters-sftp-common/src/main/java/org/springframework/cloud/stream/app/sftp/SftpSessionFactoryConfiguration.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/app-starters-common/app-starters-sftp-common/src/main/java/org/springframework/cloud/stream/app/sftp/SftpSessionFactoryProperties.java
+++ b/app-starters-common/app-starters-sftp-common/src/main/java/org/springframework/cloud/stream/app/sftp/SftpSessionFactoryProperties.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/app-starters-common/app-starters-tcp-common/src/main/java/org/springframework/cloud/stream/app/tcp/AbstractTcpConnectionFactoryProperties.java
+++ b/app-starters-common/app-starters-tcp-common/src/main/java/org/springframework/cloud/stream/app/tcp/AbstractTcpConnectionFactoryProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/app-starters-common/app-starters-tcp-common/src/main/java/org/springframework/cloud/stream/app/tcp/EncoderDecoderFactoryBean.java
+++ b/app-starters-common/app-starters-tcp-common/src/main/java/org/springframework/cloud/stream/app/tcp/EncoderDecoderFactoryBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/app-starters-common/app-starters-time-common/src/main/java/org/springframework/cloud/stream/app/time/DateFormat.java
+++ b/app-starters-common/app-starters-time-common/src/main/java/org/springframework/cloud/stream/app/time/DateFormat.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/app-starters-common/app-starters-trigger-common/src/main/java/org/springframework/cloud/stream/app/trigger/DateTrigger.java
+++ b/app-starters-common/app-starters-trigger-common/src/main/java/org/springframework/cloud/stream/app/trigger/DateTrigger.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/app-starters-common/app-starters-trigger-common/src/main/java/org/springframework/cloud/stream/app/trigger/SourcePayloadProperties.java
+++ b/app-starters-common/app-starters-trigger-common/src/main/java/org/springframework/cloud/stream/app/trigger/SourcePayloadProperties.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/app-starters-common/app-starters-trigger-common/src/main/java/org/springframework/cloud/stream/app/trigger/TriggerConfiguration.java
+++ b/app-starters-common/app-starters-trigger-common/src/main/java/org/springframework/cloud/stream/app/trigger/TriggerConfiguration.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/app-starters-common/app-starters-trigger-common/src/main/java/org/springframework/cloud/stream/app/trigger/TriggerConstants.java
+++ b/app-starters-common/app-starters-trigger-common/src/main/java/org/springframework/cloud/stream/app/trigger/TriggerConstants.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/app-starters-common/app-starters-trigger-common/src/main/java/org/springframework/cloud/stream/app/trigger/TriggerProperties.java
+++ b/app-starters-common/app-starters-trigger-common/src/main/java/org/springframework/cloud/stream/app/trigger/TriggerProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/app-starters-common/app-starters-trigger-one-common/src/main/java/org/springframework/cloud/stream/app/trigger/TriggerPropertiesMaxMessagesDefaultOne.java
+++ b/app-starters-common/app-starters-trigger-one-common/src/main/java/org/springframework/cloud/stream/app/trigger/TriggerPropertiesMaxMessagesDefaultOne.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/app-starters-common/app-starters-trigger-unlimited-common/src/main/java/org/springframework/cloud/stream/app/trigger/TriggerPropertiesMaxMessagesDefaultUnlimited.java
+++ b/app-starters-common/app-starters-trigger-unlimited-common/src/main/java/org/springframework/cloud/stream/app/trigger/TriggerPropertiesMaxMessagesDefaultUnlimited.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/app-starters-common/app-starters-twitter-common/src/main/java/org/springframework/cloud/stream/app/twitter/TwitterCredentials.java
+++ b/app-starters-common/app-starters-twitter-common/src/main/java/org/springframework/cloud/stream/app/twitter/TwitterCredentials.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/BinderTestPropertiesInitializer.java
+++ b/app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/BinderTestPropertiesInitializer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/PropertiesInitializer.java
+++ b/app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/PropertiesInitializer.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/fieldvaluecounter/FieldValueCounterSinkTestConfiguration.java
+++ b/app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/fieldvaluecounter/FieldValueCounterSinkTestConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/file/remote/RemoteFileTestSupport.java
+++ b/app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/file/remote/RemoteFileTestSupport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/ftp/FtpSinkTestConfiguration.java
+++ b/app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/ftp/FtpSinkTestConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/ftp/FtpSourceTestConfiguration.java
+++ b/app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/ftp/FtpSourceTestConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/ftp/FtpTestSupport.java
+++ b/app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/ftp/FtpTestSupport.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/gemfire/process/ProcessConfiguration.java
+++ b/app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/gemfire/process/ProcessConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/gemfire/process/ProcessExecutor.java
+++ b/app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/gemfire/process/ProcessExecutor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/gemfire/process/ProcessInputStreamListener.java
+++ b/app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/gemfire/process/ProcessInputStreamListener.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/gemfire/process/ProcessWrapper.java
+++ b/app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/gemfire/process/ProcessWrapper.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/gemfire/process/ServerProcess.java
+++ b/app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/gemfire/process/ServerProcess.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/gemfire/process/support/PidUnavailableException.java
+++ b/app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/gemfire/process/support/PidUnavailableException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/gemfire/process/support/ProcessUtils.java
+++ b/app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/gemfire/process/support/ProcessUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/gemfire/support/FileSystemUtils.java
+++ b/app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/gemfire/support/FileSystemUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/gemfire/support/IOUtils.java
+++ b/app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/gemfire/support/IOUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/gemfire/support/ThreadUtils.java
+++ b/app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/gemfire/support/ThreadUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/gemfire/support/ThrowableUtils.java
+++ b/app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/gemfire/support/ThrowableUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/hamcrest/HamcrestMatchers.java
+++ b/app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/hamcrest/HamcrestMatchers.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/http/HttpClientProcessorTestConfiguration.java
+++ b/app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/http/HttpClientProcessorTestConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/ip/IpSinkTestConfiguration.java
+++ b/app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/ip/IpSinkTestConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/ip/IpSourceTestConfiguration.java
+++ b/app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/ip/IpSourceTestConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/jdbc/JdbcSourceTestConfiguration.java
+++ b/app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/jdbc/JdbcSourceTestConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/jms/JmsSourceTestConfiguration.java
+++ b/app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/jms/JmsSourceTestConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/loadgenerator/LoadGeneratorSourceTestConfiguration.java
+++ b/app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/loadgenerator/LoadGeneratorSourceTestConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/loggregator/LoggregatorSourceTestConfiguration.java
+++ b/app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/loggregator/LoggregatorSourceTestConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/mail/PoorMansMailServer.java
+++ b/app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/mail/PoorMansMailServer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/pmml/PmmlProcessorTestConfiguration.java
+++ b/app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/pmml/PmmlProcessorTestConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/rabbit/RabbitSinkTestConfiguration.java
+++ b/app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/rabbit/RabbitSinkTestConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/rabbit/RabbitSourceTestConfiguration.java
+++ b/app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/rabbit/RabbitSourceTestConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/redis/RedisSinkTestConfiguration.java
+++ b/app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/redis/RedisSinkTestConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/script/ScriptableTestConfiguration.java
+++ b/app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/script/ScriptableTestConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/sftp/SftpSinkTestConfiguration.java
+++ b/app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/sftp/SftpSinkTestConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/sftp/SftpSourceTestConfiguration.java
+++ b/app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/sftp/SftpSourceTestConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/sftp/SftpTestSupport.java
+++ b/app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/sftp/SftpTestSupport.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/twitter/TwitterTestConfiguration.java
+++ b/app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/twitter/TwitterTestConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/aws-integration-tests/src/test/java/org/springframework/cloud/stream/app/aws/AwsIntegrationTestStackRule.java
+++ b/aws-integration-tests/src/test/java/org/springframework/cloud/stream/app/aws/AwsIntegrationTestStackRule.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/aws-integration-tests/src/test/java/org/springframework/cloud/stream/app/aws/SpringCloudStreamAwsApplicationsITCase.java
+++ b/aws-integration-tests/src/test/java/org/springframework/cloud/stream/app/aws/SpringCloudStreamAwsApplicationsITCase.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/aws-s3/spring-cloud-starter-stream-sink-s3/src/main/java/org/springframework/cloud/stream/app/s3/sink/AmazonS3SinkConfiguration.java
+++ b/aws-s3/spring-cloud-starter-stream-sink-s3/src/main/java/org/springframework/cloud/stream/app/s3/sink/AmazonS3SinkConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/aws-s3/spring-cloud-starter-stream-sink-s3/src/main/java/org/springframework/cloud/stream/app/s3/sink/AmazonS3SinkProperties.java
+++ b/aws-s3/spring-cloud-starter-stream-sink-s3/src/main/java/org/springframework/cloud/stream/app/s3/sink/AmazonS3SinkProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/aws-s3/spring-cloud-starter-stream-sink-s3/src/test/java/org/springframework/cloud/stream/app/s3/sink/AmazonS3SinkMockTests.java
+++ b/aws-s3/spring-cloud-starter-stream-sink-s3/src/test/java/org/springframework/cloud/stream/app/s3/sink/AmazonS3SinkMockTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/aws-s3/spring-cloud-starter-stream-sink-s3/src/test/java/org/springframework/cloud/stream/app/s3/sink/AmazonS3SinkPropertiesTests.java
+++ b/aws-s3/spring-cloud-starter-stream-sink-s3/src/test/java/org/springframework/cloud/stream/app/s3/sink/AmazonS3SinkPropertiesTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/aws-s3/spring-cloud-starter-stream-source-s3/src/main/java/org/springframework/cloud/stream/app/s3/source/AmazonS3SourceConfiguration.java
+++ b/aws-s3/spring-cloud-starter-stream-source-s3/src/main/java/org/springframework/cloud/stream/app/s3/source/AmazonS3SourceConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/aws-s3/spring-cloud-starter-stream-source-s3/src/main/java/org/springframework/cloud/stream/app/s3/source/AmazonS3SourceProperties.java
+++ b/aws-s3/spring-cloud-starter-stream-source-s3/src/main/java/org/springframework/cloud/stream/app/s3/source/AmazonS3SourceProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/aws-s3/spring-cloud-starter-stream-source-s3/src/test/java/org/springframework/cloud/stream/app/s3/source/AmazonS3SourceMockTests.java
+++ b/aws-s3/spring-cloud-starter-stream-source-s3/src/test/java/org/springframework/cloud/stream/app/s3/source/AmazonS3SourceMockTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/cassandra/spring-cloud-starter-stream-sink-cassandra/src/main/java/org/springframework/cloud/stream/app/cassandra/CassandraConfiguration.java
+++ b/cassandra/spring-cloud-starter-stream-sink-cassandra/src/main/java/org/springframework/cloud/stream/app/cassandra/CassandraConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/cassandra/spring-cloud-starter-stream-sink-cassandra/src/main/java/org/springframework/cloud/stream/app/cassandra/CassandraProperties.java
+++ b/cassandra/spring-cloud-starter-stream-sink-cassandra/src/main/java/org/springframework/cloud/stream/app/cassandra/CassandraProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/cassandra/spring-cloud-starter-stream-sink-cassandra/src/main/java/org/springframework/cloud/stream/app/cassandra/sink/CassandraSinkConfiguration.java
+++ b/cassandra/spring-cloud-starter-stream-sink-cassandra/src/main/java/org/springframework/cloud/stream/app/cassandra/sink/CassandraSinkConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/cassandra/spring-cloud-starter-stream-sink-cassandra/src/main/java/org/springframework/cloud/stream/app/cassandra/sink/CassandraSinkProperties.java
+++ b/cassandra/spring-cloud-starter-stream-sink-cassandra/src/main/java/org/springframework/cloud/stream/app/cassandra/sink/CassandraSinkProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/cassandra/spring-cloud-starter-stream-sink-cassandra/src/test/java/org/springframework/cloud/stream/app/cassandra/domain/Book.java
+++ b/cassandra/spring-cloud-starter-stream-sink-cassandra/src/test/java/org/springframework/cloud/stream/app/cassandra/domain/Book.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/cassandra/spring-cloud-starter-stream-sink-cassandra/src/test/java/org/springframework/cloud/stream/app/cassandra/sink/CassandraSinkIntegrationTests.java
+++ b/cassandra/spring-cloud-starter-stream-sink-cassandra/src/test/java/org/springframework/cloud/stream/app/cassandra/sink/CassandraSinkIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/cassandra/spring-cloud-starter-stream-sink-cassandra/src/test/java/org/springframework/cloud/stream/app/cassandra/sink/CassandraSinkPropertiesTests.java
+++ b/cassandra/spring-cloud-starter-stream-sink-cassandra/src/test/java/org/springframework/cloud/stream/app/cassandra/sink/CassandraSinkPropertiesTests.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/cloudfoundry/spring-cloud-starter-stream-source-loggregator/src/main/java/org/springframework/cloud/stream/app/loggregator/source/LoggregatorMessageSource.java
+++ b/cloudfoundry/spring-cloud-starter-stream-source-loggregator/src/main/java/org/springframework/cloud/stream/app/loggregator/source/LoggregatorMessageSource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/cloudfoundry/spring-cloud-starter-stream-source-loggregator/src/main/java/org/springframework/cloud/stream/app/loggregator/source/LoggregatorProperties.java
+++ b/cloudfoundry/spring-cloud-starter-stream-source-loggregator/src/main/java/org/springframework/cloud/stream/app/loggregator/source/LoggregatorProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/cloudfoundry/spring-cloud-starter-stream-source-loggregator/src/main/java/org/springframework/cloud/stream/app/loggregator/source/LoggregatorSourceConfiguration.java
+++ b/cloudfoundry/spring-cloud-starter-stream-source-loggregator/src/main/java/org/springframework/cloud/stream/app/loggregator/source/LoggregatorSourceConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/cloudfoundry/spring-cloud-starter-stream-source-loggregator/src/test/java/org/springframework/cloud/stream/app/loggregator/source/LoggregatorSourceTests.java
+++ b/cloudfoundry/spring-cloud-starter-stream-source-loggregator/src/test/java/org/springframework/cloud/stream/app/loggregator/source/LoggregatorSourceTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/file/spring-cloud-starter-stream-sink-file/src/main/java/org/springframework/cloud/stream/app/file/sink/FileSinkConfiguration.java
+++ b/file/spring-cloud-starter-stream-sink-file/src/main/java/org/springframework/cloud/stream/app/file/sink/FileSinkConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/file/spring-cloud-starter-stream-sink-file/src/main/java/org/springframework/cloud/stream/app/file/sink/FileSinkProperties.java
+++ b/file/spring-cloud-starter-stream-sink-file/src/main/java/org/springframework/cloud/stream/app/file/sink/FileSinkProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/file/spring-cloud-starter-stream-sink-file/src/test/java/org/springframework/cloud/stream/app/file/sink/FileSinkTests.java
+++ b/file/spring-cloud-starter-stream-sink-file/src/test/java/org/springframework/cloud/stream/app/file/sink/FileSinkTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/file/spring-cloud-starter-stream-source-file/src/main/java/org/springframework/cloud/stream/app/file/source/FileSourceConfiguration.java
+++ b/file/spring-cloud-starter-stream-source-file/src/main/java/org/springframework/cloud/stream/app/file/source/FileSourceConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/file/spring-cloud-starter-stream-source-file/src/main/java/org/springframework/cloud/stream/app/file/source/FileSourceProperties.java
+++ b/file/spring-cloud-starter-stream-source-file/src/main/java/org/springframework/cloud/stream/app/file/source/FileSourceProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/file/spring-cloud-starter-stream-source-file/src/test/java/org/springframework/cloud/stream/app/file/source/FileSourceTests.java
+++ b/file/spring-cloud-starter-stream-source-file/src/test/java/org/springframework/cloud/stream/app/file/source/FileSourceTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/ftp/spring-cloud-starter-stream-sink-ftp/src/main/java/org/springframework/cloud/stream/app/ftp/sink/FtpSinkConfiguration.java
+++ b/ftp/spring-cloud-starter-stream-sink-ftp/src/main/java/org/springframework/cloud/stream/app/ftp/sink/FtpSinkConfiguration.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/ftp/spring-cloud-starter-stream-sink-ftp/src/main/java/org/springframework/cloud/stream/app/ftp/sink/FtpSinkProperties.java
+++ b/ftp/spring-cloud-starter-stream-sink-ftp/src/main/java/org/springframework/cloud/stream/app/ftp/sink/FtpSinkProperties.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/ftp/spring-cloud-starter-stream-sink-ftp/src/test/java/org/springframework/cloud/stream/app/ftp/sink/FtpSinkIntegrationTests.java
+++ b/ftp/spring-cloud-starter-stream-sink-ftp/src/test/java/org/springframework/cloud/stream/app/ftp/sink/FtpSinkIntegrationTests.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/ftp/spring-cloud-starter-stream-sink-ftp/src/test/java/org/springframework/cloud/stream/app/ftp/sink/FtpSinkPropertiesTests.java
+++ b/ftp/spring-cloud-starter-stream-sink-ftp/src/test/java/org/springframework/cloud/stream/app/ftp/sink/FtpSinkPropertiesTests.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/ftp/spring-cloud-starter-stream-source-ftp/src/main/java/org/springframework/cloud/stream/app/ftp/source/FtpSourceConfiguration.java
+++ b/ftp/spring-cloud-starter-stream-source-ftp/src/main/java/org/springframework/cloud/stream/app/ftp/source/FtpSourceConfiguration.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/ftp/spring-cloud-starter-stream-source-ftp/src/main/java/org/springframework/cloud/stream/app/ftp/source/FtpSourceProperties.java
+++ b/ftp/spring-cloud-starter-stream-source-ftp/src/main/java/org/springframework/cloud/stream/app/ftp/source/FtpSourceProperties.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/ftp/spring-cloud-starter-stream-source-ftp/src/test/java/org/springframework/cloud/stream/app/ftp/source/FtpSourceIntegrationTests.java
+++ b/ftp/spring-cloud-starter-stream-source-ftp/src/test/java/org/springframework/cloud/stream/app/ftp/source/FtpSourceIntegrationTests.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/ftp/spring-cloud-starter-stream-source-ftp/src/test/java/org/springframework/cloud/stream/app/ftp/source/FtpSourcePropertiesTests.java
+++ b/ftp/spring-cloud-starter-stream-source-ftp/src/test/java/org/springframework/cloud/stream/app/ftp/source/FtpSourcePropertiesTests.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gemfire/spring-cloud-starter-stream-common-gemfire/src/main/java/org/springframework/cloud/stream/app/gemfire/JsonObjectTransformer.java
+++ b/gemfire/spring-cloud-starter-stream-common-gemfire/src/main/java/org/springframework/cloud/stream/app/gemfire/JsonObjectTransformer.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *          http://www.apache.org/licenses/LICENSE-2.0
+ *          https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gemfire/spring-cloud-starter-stream-common-gemfire/src/main/java/org/springframework/cloud/stream/app/gemfire/config/GemfireClientCacheConfiguration.java
+++ b/gemfire/spring-cloud-starter-stream-common-gemfire/src/main/java/org/springframework/cloud/stream/app/gemfire/config/GemfireClientCacheConfiguration.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *          http://www.apache.org/licenses/LICENSE-2.0
+ *          https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gemfire/spring-cloud-starter-stream-common-gemfire/src/main/java/org/springframework/cloud/stream/app/gemfire/config/GemfireClientRegionConfiguration.java
+++ b/gemfire/spring-cloud-starter-stream-common-gemfire/src/main/java/org/springframework/cloud/stream/app/gemfire/config/GemfireClientRegionConfiguration.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gemfire/spring-cloud-starter-stream-common-gemfire/src/main/java/org/springframework/cloud/stream/app/gemfire/config/GemfirePoolConfiguration.java
+++ b/gemfire/spring-cloud-starter-stream-common-gemfire/src/main/java/org/springframework/cloud/stream/app/gemfire/config/GemfirePoolConfiguration.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gemfire/spring-cloud-starter-stream-common-gemfire/src/main/java/org/springframework/cloud/stream/app/gemfire/config/GemfirePoolProperties.java
+++ b/gemfire/spring-cloud-starter-stream-common-gemfire/src/main/java/org/springframework/cloud/stream/app/gemfire/config/GemfirePoolProperties.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gemfire/spring-cloud-starter-stream-common-gemfire/src/main/java/org/springframework/cloud/stream/app/gemfire/config/GemfireRegionProperties.java
+++ b/gemfire/spring-cloud-starter-stream-common-gemfire/src/main/java/org/springframework/cloud/stream/app/gemfire/config/GemfireRegionProperties.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gemfire/spring-cloud-starter-stream-common-gemfire/src/main/java/org/springframework/cloud/stream/app/gemfire/config/InetSocketAddressConverterConfiguration.java
+++ b/gemfire/spring-cloud-starter-stream-common-gemfire/src/main/java/org/springframework/cloud/stream/app/gemfire/config/InetSocketAddressConverterConfiguration.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gemfire/spring-cloud-starter-stream-sink-gemfire/src/main/java/org/springframework/cloud/stream/app/gemfire/sink/GemfireSinkConfiguration.java
+++ b/gemfire/spring-cloud-starter-stream-sink-gemfire/src/main/java/org/springframework/cloud/stream/app/gemfire/sink/GemfireSinkConfiguration.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gemfire/spring-cloud-starter-stream-sink-gemfire/src/main/java/org/springframework/cloud/stream/app/gemfire/sink/GemfireSinkHandler.java
+++ b/gemfire/spring-cloud-starter-stream-sink-gemfire/src/main/java/org/springframework/cloud/stream/app/gemfire/sink/GemfireSinkHandler.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *          http://www.apache.org/licenses/LICENSE-2.0
+ *          https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gemfire/spring-cloud-starter-stream-sink-gemfire/src/main/java/org/springframework/cloud/stream/app/gemfire/sink/GemfireSinkProperties.java
+++ b/gemfire/spring-cloud-starter-stream-sink-gemfire/src/main/java/org/springframework/cloud/stream/app/gemfire/sink/GemfireSinkProperties.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gemfire/spring-cloud-starter-stream-sink-gemfire/src/test/java/org/springframework/cloud/stream/app/gemfire/sink/GemfireSinkConfigurationTests.java
+++ b/gemfire/spring-cloud-starter-stream-sink-gemfire/src/test/java/org/springframework/cloud/stream/app/gemfire/sink/GemfireSinkConfigurationTests.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *          http://www.apache.org/licenses/LICENSE-2.0
+ *          https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gemfire/spring-cloud-starter-stream-sink-gemfire/src/test/java/org/springframework/cloud/stream/app/gemfire/sink/GemfireSinkIntegrationTests.java
+++ b/gemfire/spring-cloud-starter-stream-sink-gemfire/src/test/java/org/springframework/cloud/stream/app/gemfire/sink/GemfireSinkIntegrationTests.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gemfire/spring-cloud-starter-stream-source-gemfire-cq/src/main/java/org/springframework/cloud/stream/app/gemfire/cq/source/GemfireCqSourceConfiguration.java
+++ b/gemfire/spring-cloud-starter-stream-source-gemfire-cq/src/main/java/org/springframework/cloud/stream/app/gemfire/cq/source/GemfireCqSourceConfiguration.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gemfire/spring-cloud-starter-stream-source-gemfire-cq/src/main/java/org/springframework/cloud/stream/app/gemfire/cq/source/GemfireCqSourceProperties.java
+++ b/gemfire/spring-cloud-starter-stream-source-gemfire-cq/src/main/java/org/springframework/cloud/stream/app/gemfire/cq/source/GemfireCqSourceProperties.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gemfire/spring-cloud-starter-stream-source-gemfire-cq/src/test/java/org/springframework/cloud/stream/app/gemfire/cq/source/GemfireCqSourceConfigurationTests.java
+++ b/gemfire/spring-cloud-starter-stream-source-gemfire-cq/src/test/java/org/springframework/cloud/stream/app/gemfire/cq/source/GemfireCqSourceConfigurationTests.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *          http://www.apache.org/licenses/LICENSE-2.0
+ *          https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gemfire/spring-cloud-starter-stream-source-gemfire/src/main/java/org/springframework/cloud/stream/app/gemfire/source/GemfireSourceConfiguration.java
+++ b/gemfire/spring-cloud-starter-stream-source-gemfire/src/main/java/org/springframework/cloud/stream/app/gemfire/source/GemfireSourceConfiguration.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gemfire/spring-cloud-starter-stream-source-gemfire/src/main/java/org/springframework/cloud/stream/app/gemfire/source/GemfireSourceProperties.java
+++ b/gemfire/spring-cloud-starter-stream-source-gemfire/src/main/java/org/springframework/cloud/stream/app/gemfire/source/GemfireSourceProperties.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gemfire/spring-cloud-starter-stream-source-gemfire/src/main/java/org/springframework/cloud/stream/app/gemfire/source/KeyInterestConfiguration.java
+++ b/gemfire/spring-cloud-starter-stream-source-gemfire/src/main/java/org/springframework/cloud/stream/app/gemfire/source/KeyInterestConfiguration.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *          http://www.apache.org/licenses/LICENSE-2.0
+ *          https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gemfire/spring-cloud-starter-stream-source-gemfire/src/test/java/org/springframework/cloud/stream/app/gemfire/source/GemfireSourceConfigurationTests.java
+++ b/gemfire/spring-cloud-starter-stream-source-gemfire/src/test/java/org/springframework/cloud/stream/app/gemfire/source/GemfireSourceConfigurationTests.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *          http://www.apache.org/licenses/LICENSE-2.0
+ *          https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gpfdist/spring-cloud-starter-stream-sink-gpfdist/src/main/java/org/springframework/cloud/stream/app/gpfdist/sink/AbstractGpfdistMessageHandler.java
+++ b/gpfdist/spring-cloud-starter-stream-sink-gpfdist/src/main/java/org/springframework/cloud/stream/app/gpfdist/sink/AbstractGpfdistMessageHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gpfdist/spring-cloud-starter-stream-sink-gpfdist/src/main/java/org/springframework/cloud/stream/app/gpfdist/sink/GpfdistCodec.java
+++ b/gpfdist/spring-cloud-starter-stream-sink-gpfdist/src/main/java/org/springframework/cloud/stream/app/gpfdist/sink/GpfdistCodec.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gpfdist/spring-cloud-starter-stream-sink-gpfdist/src/main/java/org/springframework/cloud/stream/app/gpfdist/sink/GpfdistMessageHandler.java
+++ b/gpfdist/spring-cloud-starter-stream-sink-gpfdist/src/main/java/org/springframework/cloud/stream/app/gpfdist/sink/GpfdistMessageHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gpfdist/spring-cloud-starter-stream-sink-gpfdist/src/main/java/org/springframework/cloud/stream/app/gpfdist/sink/GpfdistServer.java
+++ b/gpfdist/spring-cloud-starter-stream-sink-gpfdist/src/main/java/org/springframework/cloud/stream/app/gpfdist/sink/GpfdistServer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gpfdist/spring-cloud-starter-stream-sink-gpfdist/src/main/java/org/springframework/cloud/stream/app/gpfdist/sink/GpfdistSinkApplication.java
+++ b/gpfdist/spring-cloud-starter-stream-sink-gpfdist/src/main/java/org/springframework/cloud/stream/app/gpfdist/sink/GpfdistSinkApplication.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gpfdist/spring-cloud-starter-stream-sink-gpfdist/src/main/java/org/springframework/cloud/stream/app/gpfdist/sink/GpfdistSinkConfiguration.java
+++ b/gpfdist/spring-cloud-starter-stream-sink-gpfdist/src/main/java/org/springframework/cloud/stream/app/gpfdist/sink/GpfdistSinkConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gpfdist/spring-cloud-starter-stream-sink-gpfdist/src/main/java/org/springframework/cloud/stream/app/gpfdist/sink/GpfdistSinkProperties.java
+++ b/gpfdist/spring-cloud-starter-stream-sink-gpfdist/src/main/java/org/springframework/cloud/stream/app/gpfdist/sink/GpfdistSinkProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gpfdist/spring-cloud-starter-stream-sink-gpfdist/src/main/java/org/springframework/cloud/stream/app/gpfdist/sink/HostInfoDiscoveryProperties.java
+++ b/gpfdist/spring-cloud-starter-stream-sink-gpfdist/src/main/java/org/springframework/cloud/stream/app/gpfdist/sink/HostInfoDiscoveryProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gpfdist/spring-cloud-starter-stream-sink-gpfdist/src/main/java/org/springframework/cloud/stream/app/gpfdist/sink/support/AbstractExternalTable.java
+++ b/gpfdist/spring-cloud-starter-stream-sink-gpfdist/src/main/java/org/springframework/cloud/stream/app/gpfdist/sink/support/AbstractExternalTable.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gpfdist/spring-cloud-starter-stream-sink-gpfdist/src/main/java/org/springframework/cloud/stream/app/gpfdist/sink/support/ControlFile.java
+++ b/gpfdist/spring-cloud-starter-stream-sink-gpfdist/src/main/java/org/springframework/cloud/stream/app/gpfdist/sink/support/ControlFile.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gpfdist/spring-cloud-starter-stream-sink-gpfdist/src/main/java/org/springframework/cloud/stream/app/gpfdist/sink/support/ControlFileFactoryBean.java
+++ b/gpfdist/spring-cloud-starter-stream-sink-gpfdist/src/main/java/org/springframework/cloud/stream/app/gpfdist/sink/support/ControlFileFactoryBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gpfdist/spring-cloud-starter-stream-sink-gpfdist/src/main/java/org/springframework/cloud/stream/app/gpfdist/sink/support/DefaultGreenplumLoad.java
+++ b/gpfdist/spring-cloud-starter-stream-sink-gpfdist/src/main/java/org/springframework/cloud/stream/app/gpfdist/sink/support/DefaultGreenplumLoad.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gpfdist/spring-cloud-starter-stream-sink-gpfdist/src/main/java/org/springframework/cloud/stream/app/gpfdist/sink/support/DefaultLoadService.java
+++ b/gpfdist/spring-cloud-starter-stream-sink-gpfdist/src/main/java/org/springframework/cloud/stream/app/gpfdist/sink/support/DefaultLoadService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gpfdist/spring-cloud-starter-stream-sink-gpfdist/src/main/java/org/springframework/cloud/stream/app/gpfdist/sink/support/Format.java
+++ b/gpfdist/spring-cloud-starter-stream-sink-gpfdist/src/main/java/org/springframework/cloud/stream/app/gpfdist/sink/support/Format.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gpfdist/spring-cloud-starter-stream-sink-gpfdist/src/main/java/org/springframework/cloud/stream/app/gpfdist/sink/support/GreenplumDataSourceFactoryBean.java
+++ b/gpfdist/spring-cloud-starter-stream-sink-gpfdist/src/main/java/org/springframework/cloud/stream/app/gpfdist/sink/support/GreenplumDataSourceFactoryBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gpfdist/spring-cloud-starter-stream-sink-gpfdist/src/main/java/org/springframework/cloud/stream/app/gpfdist/sink/support/GreenplumLoad.java
+++ b/gpfdist/spring-cloud-starter-stream-sink-gpfdist/src/main/java/org/springframework/cloud/stream/app/gpfdist/sink/support/GreenplumLoad.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gpfdist/spring-cloud-starter-stream-sink-gpfdist/src/main/java/org/springframework/cloud/stream/app/gpfdist/sink/support/JdbcCommands.java
+++ b/gpfdist/spring-cloud-starter-stream-sink-gpfdist/src/main/java/org/springframework/cloud/stream/app/gpfdist/sink/support/JdbcCommands.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gpfdist/spring-cloud-starter-stream-sink-gpfdist/src/main/java/org/springframework/cloud/stream/app/gpfdist/sink/support/LoadConfiguration.java
+++ b/gpfdist/spring-cloud-starter-stream-sink-gpfdist/src/main/java/org/springframework/cloud/stream/app/gpfdist/sink/support/LoadConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gpfdist/spring-cloud-starter-stream-sink-gpfdist/src/main/java/org/springframework/cloud/stream/app/gpfdist/sink/support/LoadConfigurationFactoryBean.java
+++ b/gpfdist/spring-cloud-starter-stream-sink-gpfdist/src/main/java/org/springframework/cloud/stream/app/gpfdist/sink/support/LoadConfigurationFactoryBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gpfdist/spring-cloud-starter-stream-sink-gpfdist/src/main/java/org/springframework/cloud/stream/app/gpfdist/sink/support/LoadFactoryBean.java
+++ b/gpfdist/spring-cloud-starter-stream-sink-gpfdist/src/main/java/org/springframework/cloud/stream/app/gpfdist/sink/support/LoadFactoryBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gpfdist/spring-cloud-starter-stream-sink-gpfdist/src/main/java/org/springframework/cloud/stream/app/gpfdist/sink/support/LoadService.java
+++ b/gpfdist/spring-cloud-starter-stream-sink-gpfdist/src/main/java/org/springframework/cloud/stream/app/gpfdist/sink/support/LoadService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gpfdist/spring-cloud-starter-stream-sink-gpfdist/src/main/java/org/springframework/cloud/stream/app/gpfdist/sink/support/Mode.java
+++ b/gpfdist/spring-cloud-starter-stream-sink-gpfdist/src/main/java/org/springframework/cloud/stream/app/gpfdist/sink/support/Mode.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gpfdist/spring-cloud-starter-stream-sink-gpfdist/src/main/java/org/springframework/cloud/stream/app/gpfdist/sink/support/NetworkUtils.java
+++ b/gpfdist/spring-cloud-starter-stream-sink-gpfdist/src/main/java/org/springframework/cloud/stream/app/gpfdist/sink/support/NetworkUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gpfdist/spring-cloud-starter-stream-sink-gpfdist/src/main/java/org/springframework/cloud/stream/app/gpfdist/sink/support/ReadableTable.java
+++ b/gpfdist/spring-cloud-starter-stream-sink-gpfdist/src/main/java/org/springframework/cloud/stream/app/gpfdist/sink/support/ReadableTable.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gpfdist/spring-cloud-starter-stream-sink-gpfdist/src/main/java/org/springframework/cloud/stream/app/gpfdist/sink/support/ReadableTableFactoryBean.java
+++ b/gpfdist/spring-cloud-starter-stream-sink-gpfdist/src/main/java/org/springframework/cloud/stream/app/gpfdist/sink/support/ReadableTableFactoryBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gpfdist/spring-cloud-starter-stream-sink-gpfdist/src/main/java/org/springframework/cloud/stream/app/gpfdist/sink/support/RuntimeContext.java
+++ b/gpfdist/spring-cloud-starter-stream-sink-gpfdist/src/main/java/org/springframework/cloud/stream/app/gpfdist/sink/support/RuntimeContext.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gpfdist/spring-cloud-starter-stream-sink-gpfdist/src/main/java/org/springframework/cloud/stream/app/gpfdist/sink/support/SegmentRejectType.java
+++ b/gpfdist/spring-cloud-starter-stream-sink-gpfdist/src/main/java/org/springframework/cloud/stream/app/gpfdist/sink/support/SegmentRejectType.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gpfdist/spring-cloud-starter-stream-sink-gpfdist/src/main/java/org/springframework/cloud/stream/app/gpfdist/sink/support/SqlUtils.java
+++ b/gpfdist/spring-cloud-starter-stream-sink-gpfdist/src/main/java/org/springframework/cloud/stream/app/gpfdist/sink/support/SqlUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gpfdist/spring-cloud-starter-stream-sink-gpfdist/src/test/java/org/springframework/cloud/stream/app/gpfdist/sink/AbstractDbTests.java
+++ b/gpfdist/spring-cloud-starter-stream-sink-gpfdist/src/test/java/org/springframework/cloud/stream/app/gpfdist/sink/AbstractDbTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gpfdist/spring-cloud-starter-stream-sink-gpfdist/src/test/java/org/springframework/cloud/stream/app/gpfdist/sink/AbstractLoadTests.java
+++ b/gpfdist/spring-cloud-starter-stream-sink-gpfdist/src/test/java/org/springframework/cloud/stream/app/gpfdist/sink/AbstractLoadTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gpfdist/spring-cloud-starter-stream-sink-gpfdist/src/test/java/org/springframework/cloud/stream/app/gpfdist/sink/GpfdistSinkPropertiesTests.java
+++ b/gpfdist/spring-cloud-starter-stream-sink-gpfdist/src/test/java/org/springframework/cloud/stream/app/gpfdist/sink/GpfdistSinkPropertiesTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gpfdist/spring-cloud-starter-stream-sink-gpfdist/src/test/java/org/springframework/cloud/stream/app/gpfdist/sink/HostInfoDiscoveryPropertiesTests.java
+++ b/gpfdist/spring-cloud-starter-stream-sink-gpfdist/src/test/java/org/springframework/cloud/stream/app/gpfdist/sink/HostInfoDiscoveryPropertiesTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gpfdist/spring-cloud-starter-stream-sink-gpfdist/src/test/java/org/springframework/cloud/stream/app/gpfdist/sink/LoadIT.java
+++ b/gpfdist/spring-cloud-starter-stream-sink-gpfdist/src/test/java/org/springframework/cloud/stream/app/gpfdist/sink/LoadIT.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gpfdist/spring-cloud-starter-stream-sink-gpfdist/src/test/java/org/springframework/cloud/stream/app/gpfdist/sink/TestListenAddress.java
+++ b/gpfdist/spring-cloud-starter-stream-sink-gpfdist/src/test/java/org/springframework/cloud/stream/app/gpfdist/sink/TestListenAddress.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gpfdist/spring-cloud-starter-stream-sink-gpfdist/src/test/java/org/springframework/cloud/stream/app/gpfdist/sink/TestUtils.java
+++ b/gpfdist/spring-cloud-starter-stream-sink-gpfdist/src/test/java/org/springframework/cloud/stream/app/gpfdist/sink/TestUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gpfdist/spring-cloud-starter-stream-sink-gpfdist/src/test/java/org/springframework/cloud/stream/app/gpfdist/sink/support/ControlFileTests.java
+++ b/gpfdist/spring-cloud-starter-stream-sink-gpfdist/src/test/java/org/springframework/cloud/stream/app/gpfdist/sink/support/ControlFileTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gpfdist/spring-cloud-starter-stream-sink-gpfdist/src/test/java/org/springframework/cloud/stream/app/gpfdist/sink/support/LoadConfigurationFactoryBeanTests.java
+++ b/gpfdist/spring-cloud-starter-stream-sink-gpfdist/src/test/java/org/springframework/cloud/stream/app/gpfdist/sink/support/LoadConfigurationFactoryBeanTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gpfdist/spring-cloud-starter-stream-sink-gpfdist/src/test/java/org/springframework/cloud/stream/app/gpfdist/sink/support/LoadConfigurationIT.java
+++ b/gpfdist/spring-cloud-starter-stream-sink-gpfdist/src/test/java/org/springframework/cloud/stream/app/gpfdist/sink/support/LoadConfigurationIT.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/hdfs/spring-cloud-starter-stream-sink-hdfs-dataset/src/main/java/org/springframework/cloud/stream/app/hdfs/dataset/sink/HdfsDatasetSinkConfiguration.java
+++ b/hdfs/spring-cloud-starter-stream-sink-hdfs-dataset/src/main/java/org/springframework/cloud/stream/app/hdfs/dataset/sink/HdfsDatasetSinkConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/hdfs/spring-cloud-starter-stream-sink-hdfs-dataset/src/main/java/org/springframework/cloud/stream/app/hdfs/dataset/sink/HdfsDatasetSinkProperties.java
+++ b/hdfs/spring-cloud-starter-stream-sink-hdfs-dataset/src/main/java/org/springframework/cloud/stream/app/hdfs/dataset/sink/HdfsDatasetSinkProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/hdfs/spring-cloud-starter-stream-sink-hdfs-dataset/src/test/java/org/springframework/cloud/stream/app/hdfs/dataset/domain/TestPojo.java
+++ b/hdfs/spring-cloud-starter-stream-sink-hdfs-dataset/src/test/java/org/springframework/cloud/stream/app/hdfs/dataset/domain/TestPojo.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/hdfs/spring-cloud-starter-stream-sink-hdfs-dataset/src/test/java/org/springframework/cloud/stream/app/hdfs/dataset/sink/DatasetSinkIntegrationTests.java
+++ b/hdfs/spring-cloud-starter-stream-sink-hdfs-dataset/src/test/java/org/springframework/cloud/stream/app/hdfs/dataset/sink/DatasetSinkIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/hdfs/spring-cloud-starter-stream-sink-hdfs-dataset/src/test/java/org/springframework/cloud/stream/app/hdfs/dataset/sink/DatasetSinkPropertiesTests.java
+++ b/hdfs/spring-cloud-starter-stream-sink-hdfs-dataset/src/test/java/org/springframework/cloud/stream/app/hdfs/dataset/sink/DatasetSinkPropertiesTests.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/hdfs/spring-cloud-starter-stream-sink-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/sink/DataStoreWriterFactoryBean.java
+++ b/hdfs/spring-cloud-starter-stream-sink-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/sink/DataStoreWriterFactoryBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/hdfs/spring-cloud-starter-stream-sink-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/sink/HdfsSinkConfiguration.java
+++ b/hdfs/spring-cloud-starter-stream-sink-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/sink/HdfsSinkConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/hdfs/spring-cloud-starter-stream-sink-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/sink/HdfsSinkProperties.java
+++ b/hdfs/spring-cloud-starter-stream-sink-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/sink/HdfsSinkProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/hdfs/spring-cloud-starter-stream-sink-hdfs/src/test/java/org/springframework/cloud/stream/app/hdfs/sink/HdfsSinkConfigurationTests.java
+++ b/hdfs/spring-cloud-starter-stream-sink-hdfs/src/test/java/org/springframework/cloud/stream/app/hdfs/sink/HdfsSinkConfigurationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/hdfs/spring-cloud-starter-stream-sink-hdfs/src/test/java/org/springframework/cloud/stream/app/hdfs/sink/HdfsSinkIntegrationTests.java
+++ b/hdfs/spring-cloud-starter-stream-sink-hdfs/src/test/java/org/springframework/cloud/stream/app/hdfs/sink/HdfsSinkIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/hdfs/spring-cloud-starter-stream-sink-hdfs/src/test/java/org/springframework/cloud/stream/app/hdfs/sink/HdfsSinkPropertiesTests.java
+++ b/hdfs/spring-cloud-starter-stream-sink-hdfs/src/test/java/org/springframework/cloud/stream/app/hdfs/sink/HdfsSinkPropertiesTests.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/http/spring-cloud-starter-stream-source-http/src/main/java/org/springframework/cloud/stream/app/http/source/HttpSourceConfiguration.java
+++ b/http/spring-cloud-starter-stream-source-http/src/main/java/org/springframework/cloud/stream/app/http/source/HttpSourceConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/http/spring-cloud-starter-stream-source-http/src/test/java/org/springframework/cloud/stream/app/http/source/HttpSourceTests.java
+++ b/http/spring-cloud-starter-stream-source-http/src/test/java/org/springframework/cloud/stream/app/http/source/HttpSourceTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/jdbc/spring-cloud-starter-stream-sink-jdbc/src/main/java/org/springframework/cloud/stream/app/jdbc/sink/DefaultInitializationScriptResource.java
+++ b/jdbc/spring-cloud-starter-stream-sink-jdbc/src/main/java/org/springframework/cloud/stream/app/jdbc/sink/DefaultInitializationScriptResource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/jdbc/spring-cloud-starter-stream-sink-jdbc/src/main/java/org/springframework/cloud/stream/app/jdbc/sink/JdbcSinkConfiguration.java
+++ b/jdbc/spring-cloud-starter-stream-sink-jdbc/src/main/java/org/springframework/cloud/stream/app/jdbc/sink/JdbcSinkConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/jdbc/spring-cloud-starter-stream-sink-jdbc/src/main/java/org/springframework/cloud/stream/app/jdbc/sink/JdbcSinkProperties.java
+++ b/jdbc/spring-cloud-starter-stream-sink-jdbc/src/main/java/org/springframework/cloud/stream/app/jdbc/sink/JdbcSinkProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/jdbc/spring-cloud-starter-stream-sink-jdbc/src/main/java/org/springframework/cloud/stream/app/jdbc/sink/ShorthandMapConverter.java
+++ b/jdbc/spring-cloud-starter-stream-sink-jdbc/src/main/java/org/springframework/cloud/stream/app/jdbc/sink/ShorthandMapConverter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/jdbc/spring-cloud-starter-stream-sink-jdbc/src/main/java/org/springframework/cloud/stream/app/jdbc/sink/SupportsShorthands.java
+++ b/jdbc/spring-cloud-starter-stream-sink-jdbc/src/main/java/org/springframework/cloud/stream/app/jdbc/sink/SupportsShorthands.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/jdbc/spring-cloud-starter-stream-sink-jdbc/src/test/java/org/springframework/cloud/stream/app/jdbc/sink/JdbcSinkIntegrationTests.java
+++ b/jdbc/spring-cloud-starter-stream-sink-jdbc/src/test/java/org/springframework/cloud/stream/app/jdbc/sink/JdbcSinkIntegrationTests.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/jdbc/spring-cloud-starter-stream-sink-jdbc/src/test/java/org/springframework/cloud/stream/app/jdbc/sink/ShorthandMapConverterTests.java
+++ b/jdbc/spring-cloud-starter-stream-sink-jdbc/src/test/java/org/springframework/cloud/stream/app/jdbc/sink/ShorthandMapConverterTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/jdbc/spring-cloud-starter-stream-source-jdbc/src/main/java/org/springframework/cloud/stream/app/jdbc/source/JdbcSourceConfiguration.java
+++ b/jdbc/spring-cloud-starter-stream-source-jdbc/src/main/java/org/springframework/cloud/stream/app/jdbc/source/JdbcSourceConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/jdbc/spring-cloud-starter-stream-source-jdbc/src/main/java/org/springframework/cloud/stream/app/jdbc/source/JdbcSourceProperties.java
+++ b/jdbc/spring-cloud-starter-stream-source-jdbc/src/main/java/org/springframework/cloud/stream/app/jdbc/source/JdbcSourceProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/jdbc/spring-cloud-starter-stream-source-jdbc/src/test/java/org/springframework/cloud/stream/app/jdbc/source/JdbcSourceIntegrationTests.java
+++ b/jdbc/spring-cloud-starter-stream-source-jdbc/src/test/java/org/springframework/cloud/stream/app/jdbc/source/JdbcSourceIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/jdbc/spring-cloud-starter-stream-source-jdbc/src/test/java/org/springframework/cloud/stream/app/jdbc/source/JdbcSourcePropertiesTests.java
+++ b/jdbc/spring-cloud-starter-stream-source-jdbc/src/test/java/org/springframework/cloud/stream/app/jdbc/source/JdbcSourcePropertiesTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/jms/spring-cloud-starter-stream-source-jms/src/main/java/org/springframework/cloud/stream/app/jms/source/JmsSourceConfiguration.java
+++ b/jms/spring-cloud-starter-stream-source-jms/src/main/java/org/springframework/cloud/stream/app/jms/source/JmsSourceConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/jms/spring-cloud-starter-stream-source-jms/src/main/java/org/springframework/cloud/stream/app/jms/source/JmsSourceProperties.java
+++ b/jms/spring-cloud-starter-stream-source-jms/src/main/java/org/springframework/cloud/stream/app/jms/source/JmsSourceProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/jms/spring-cloud-starter-stream-source-jms/src/test/java/org/springframework/cloud/stream/app/jms/source/JmsSourceTests.java
+++ b/jms/spring-cloud-starter-stream-source-jms/src/test/java/org/springframework/cloud/stream/app/jms/source/JmsSourceTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/log/spring-cloud-starter-stream-sink-log/src/main/java/org/springframework/cloud/stream/app/log/sink/LogSinkConfiguration.java
+++ b/log/spring-cloud-starter-stream-sink-log/src/main/java/org/springframework/cloud/stream/app/log/sink/LogSinkConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/log/spring-cloud-starter-stream-sink-log/src/main/java/org/springframework/cloud/stream/app/log/sink/LogSinkProperties.java
+++ b/log/spring-cloud-starter-stream-sink-log/src/main/java/org/springframework/cloud/stream/app/log/sink/LogSinkProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/log/spring-cloud-starter-stream-sink-log/src/test/java/org/springframework/cloud/stream/app/log/sink/LogSinkApplicationTests.java
+++ b/log/spring-cloud-starter-stream-sink-log/src/test/java/org/springframework/cloud/stream/app/log/sink/LogSinkApplicationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/mail/spring-cloud-starter-stream-source-mail/src/main/java/org/springframework/cloud/stream/app/mail/source/MailSourceConfiguration.java
+++ b/mail/spring-cloud-starter-stream-source-mail/src/main/java/org/springframework/cloud/stream/app/mail/source/MailSourceConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/mail/spring-cloud-starter-stream-source-mail/src/main/java/org/springframework/cloud/stream/app/mail/source/MailSourceProperties.java
+++ b/mail/spring-cloud-starter-stream-source-mail/src/main/java/org/springframework/cloud/stream/app/mail/source/MailSourceProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/mail/spring-cloud-starter-stream-source-mail/src/test/java/org/springframework/cloud/stream/app/mail/source/MailSourceConfigurationTests.java
+++ b/mail/spring-cloud-starter-stream-source-mail/src/test/java/org/springframework/cloud/stream/app/mail/source/MailSourceConfigurationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/metrics/spring-cloud-starter-stream-sink-aggregate-counter/src/main/java/org/springframework/cloud/stream/app/aggregate/counter/sink/AggregateCounterSinkConfiguration.java
+++ b/metrics/spring-cloud-starter-stream-sink-aggregate-counter/src/main/java/org/springframework/cloud/stream/app/aggregate/counter/sink/AggregateCounterSinkConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/metrics/spring-cloud-starter-stream-sink-aggregate-counter/src/main/java/org/springframework/cloud/stream/app/aggregate/counter/sink/AggregateCounterSinkProperties.java
+++ b/metrics/spring-cloud-starter-stream-sink-aggregate-counter/src/main/java/org/springframework/cloud/stream/app/aggregate/counter/sink/AggregateCounterSinkProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/metrics/spring-cloud-starter-stream-sink-aggregate-counter/src/main/java/org/springframework/cloud/stream/app/aggregate/counter/sink/AggregateCounterSinkStoreConfiguration.java
+++ b/metrics/spring-cloud-starter-stream-sink-aggregate-counter/src/main/java/org/springframework/cloud/stream/app/aggregate/counter/sink/AggregateCounterSinkStoreConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/metrics/spring-cloud-starter-stream-sink-aggregate-counter/src/test/java/org/springframework/cloud/stream/app/aggregate/counter/sink/AggregateCounterTests.java
+++ b/metrics/spring-cloud-starter-stream-sink-aggregate-counter/src/test/java/org/springframework/cloud/stream/app/aggregate/counter/sink/AggregateCounterTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/metrics/spring-cloud-starter-stream-sink-aggregate-counter/src/test/java/org/springframework/cloud/stream/app/aggregate/counter/sink/TestAggregateCounterSinkApplication.java
+++ b/metrics/spring-cloud-starter-stream-sink-aggregate-counter/src/test/java/org/springframework/cloud/stream/app/aggregate/counter/sink/TestAggregateCounterSinkApplication.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/metrics/spring-cloud-starter-stream-sink-counter/src/main/java/org/springframework/cloud/stream/app/counter/sink/CounterProperties.java
+++ b/metrics/spring-cloud-starter-stream-sink-counter/src/main/java/org/springframework/cloud/stream/app/counter/sink/CounterProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/metrics/spring-cloud-starter-stream-sink-counter/src/main/java/org/springframework/cloud/stream/app/counter/sink/CounterSinkConfiguration.java
+++ b/metrics/spring-cloud-starter-stream-sink-counter/src/main/java/org/springframework/cloud/stream/app/counter/sink/CounterSinkConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/metrics/spring-cloud-starter-stream-sink-counter/src/main/java/org/springframework/cloud/stream/app/counter/sink/CounterSinkStoreConfiguration.java
+++ b/metrics/spring-cloud-starter-stream-sink-counter/src/main/java/org/springframework/cloud/stream/app/counter/sink/CounterSinkStoreConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/metrics/spring-cloud-starter-stream-sink-counter/src/test/java/org/springframework/cloud/stream/app/counter/sink/AbstractCounterSinkTests.java
+++ b/metrics/spring-cloud-starter-stream-sink-counter/src/test/java/org/springframework/cloud/stream/app/counter/sink/AbstractCounterSinkTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/metrics/spring-cloud-starter-stream-sink-counter/src/test/java/org/springframework/cloud/stream/app/counter/sink/CounterSinkDefaultNameTests.java
+++ b/metrics/spring-cloud-starter-stream-sink-counter/src/test/java/org/springframework/cloud/stream/app/counter/sink/CounterSinkDefaultNameTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/metrics/spring-cloud-starter-stream-sink-counter/src/test/java/org/springframework/cloud/stream/app/counter/sink/CounterSinkExpressionNameTests.java
+++ b/metrics/spring-cloud-starter-stream-sink-counter/src/test/java/org/springframework/cloud/stream/app/counter/sink/CounterSinkExpressionNameTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/metrics/spring-cloud-starter-stream-sink-counter/src/test/java/org/springframework/cloud/stream/app/counter/sink/CounterSinkNameTests.java
+++ b/metrics/spring-cloud-starter-stream-sink-counter/src/test/java/org/springframework/cloud/stream/app/counter/sink/CounterSinkNameTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/metrics/spring-cloud-starter-stream-sink-field-value-counter/src/main/java/org/springframework/cloud/stream/app/field/value/counter/sink/FieldValueCounterSinkConfiguration.java
+++ b/metrics/spring-cloud-starter-stream-sink-field-value-counter/src/main/java/org/springframework/cloud/stream/app/field/value/counter/sink/FieldValueCounterSinkConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/metrics/spring-cloud-starter-stream-sink-field-value-counter/src/main/java/org/springframework/cloud/stream/app/field/value/counter/sink/FieldValueCounterSinkProperties.java
+++ b/metrics/spring-cloud-starter-stream-sink-field-value-counter/src/main/java/org/springframework/cloud/stream/app/field/value/counter/sink/FieldValueCounterSinkProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/metrics/spring-cloud-starter-stream-sink-field-value-counter/src/main/java/org/springframework/cloud/stream/app/field/value/counter/sink/FieldValueCounterSinkStoreConfiguration.java
+++ b/metrics/spring-cloud-starter-stream-sink-field-value-counter/src/main/java/org/springframework/cloud/stream/app/field/value/counter/sink/FieldValueCounterSinkStoreConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/metrics/spring-cloud-starter-stream-sink-field-value-counter/src/test/java/org/springframework/cloud/stream/app/field/value/counter/sink/FieldValueCounterSinkTests.java
+++ b/metrics/spring-cloud-starter-stream-sink-field-value-counter/src/test/java/org/springframework/cloud/stream/app/field/value/counter/sink/FieldValueCounterSinkTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/metrics/spring-cloud-starter-stream-sink-field-value-counter/src/test/java/org/springframework/cloud/stream/app/field/value/counter/sink/FieldValueCounterSinkWithDefaultsTests.java
+++ b/metrics/spring-cloud-starter-stream-sink-field-value-counter/src/test/java/org/springframework/cloud/stream/app/field/value/counter/sink/FieldValueCounterSinkWithDefaultsTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/metrics/spring-cloud-starter-stream-sink-field-value-counter/src/test/java/org/springframework/cloud/stream/app/field/value/counter/sink/TestFieldValueCounterSinkApplication.java
+++ b/metrics/spring-cloud-starter-stream-sink-field-value-counter/src/test/java/org/springframework/cloud/stream/app/field/value/counter/sink/TestFieldValueCounterSinkApplication.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/mongodb/spring-cloud-starter-stream-source-mongodb/src/main/java/org/springframework/cloud/stream/app/mongodb/source/MongodbSourceConfiguration.java
+++ b/mongodb/spring-cloud-starter-stream-source-mongodb/src/main/java/org/springframework/cloud/stream/app/mongodb/source/MongodbSourceConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/mongodb/spring-cloud-starter-stream-source-mongodb/src/main/java/org/springframework/cloud/stream/app/mongodb/source/MongodbSourceProperties.java
+++ b/mongodb/spring-cloud-starter-stream-source-mongodb/src/main/java/org/springframework/cloud/stream/app/mongodb/source/MongodbSourceProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/mongodb/spring-cloud-starter-stream-source-mongodb/src/test/java/org/springframework/cloud/stream/app/mongodb/source/MongodbSourceApplicationTests.java
+++ b/mongodb/spring-cloud-starter-stream-source-mongodb/src/test/java/org/springframework/cloud/stream/app/mongodb/source/MongodbSourceApplicationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/processor/spring-cloud-starter-stream-processor-bridge/src/main/java/org/springframework/cloud/stream/app/bridge/processor/BridgeProcessorConfiguration.java
+++ b/processor/spring-cloud-starter-stream-processor-bridge/src/main/java/org/springframework/cloud/stream/app/bridge/processor/BridgeProcessorConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/processor/spring-cloud-starter-stream-processor-bridge/src/test/java/org/springframework/cloud/stream/app/bridge/processor/BridgeProcessorIntegrationTests.java
+++ b/processor/spring-cloud-starter-stream-processor-bridge/src/test/java/org/springframework/cloud/stream/app/bridge/processor/BridgeProcessorIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/processor/spring-cloud-starter-stream-processor-filter/src/main/java/org/springframework/cloud/stream/app/filter/processor/FilterProcessorConfiguration.java
+++ b/processor/spring-cloud-starter-stream-processor-filter/src/main/java/org/springframework/cloud/stream/app/filter/processor/FilterProcessorConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/processor/spring-cloud-starter-stream-processor-filter/src/main/java/org/springframework/cloud/stream/app/filter/processor/FilterProcessorProperties.java
+++ b/processor/spring-cloud-starter-stream-processor-filter/src/main/java/org/springframework/cloud/stream/app/filter/processor/FilterProcessorProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/processor/spring-cloud-starter-stream-processor-filter/src/test/java/org/springframework/cloud/stream/app/filter/processor/FilterProcessorIntegrationTests.java
+++ b/processor/spring-cloud-starter-stream-processor-filter/src/test/java/org/springframework/cloud/stream/app/filter/processor/FilterProcessorIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/processor/spring-cloud-starter-stream-processor-groovy-filter/src/main/java/org/springframework/cloud/stream/app/groovy/filter/processor/GroovyFilterProcessorConfiguration.java
+++ b/processor/spring-cloud-starter-stream-processor-groovy-filter/src/main/java/org/springframework/cloud/stream/app/groovy/filter/processor/GroovyFilterProcessorConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/processor/spring-cloud-starter-stream-processor-groovy-filter/src/main/java/org/springframework/cloud/stream/app/groovy/filter/processor/GroovyFilterProcessorProperties.java
+++ b/processor/spring-cloud-starter-stream-processor-groovy-filter/src/main/java/org/springframework/cloud/stream/app/groovy/filter/processor/GroovyFilterProcessorProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/processor/spring-cloud-starter-stream-processor-groovy-filter/src/main/java/org/springframework/cloud/stream/app/groovy/filter/processor/ScriptVariableGeneratorConfiguration.java
+++ b/processor/spring-cloud-starter-stream-processor-groovy-filter/src/main/java/org/springframework/cloud/stream/app/groovy/filter/processor/ScriptVariableGeneratorConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/processor/spring-cloud-starter-stream-processor-groovy-filter/src/test/java/org/springframework/cloud/stream/app/groovy/filter/processor/GroovyFilterProcessorApplicationIntegrationTests.java
+++ b/processor/spring-cloud-starter-stream-processor-groovy-filter/src/test/java/org/springframework/cloud/stream/app/groovy/filter/processor/GroovyFilterProcessorApplicationIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/processor/spring-cloud-starter-stream-processor-groovy-filter/src/test/resources/script.groovy
+++ b/processor/spring-cloud-starter-stream-processor-groovy-filter/src/test/resources/script.groovy
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/processor/spring-cloud-starter-stream-processor-groovy-transform/src/main/java/org/springframework/cloud/stream/app/groovy/transform/processor/GroovyTransformProcessorConfiguration.java
+++ b/processor/spring-cloud-starter-stream-processor-groovy-transform/src/main/java/org/springframework/cloud/stream/app/groovy/transform/processor/GroovyTransformProcessorConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/processor/spring-cloud-starter-stream-processor-groovy-transform/src/main/java/org/springframework/cloud/stream/app/groovy/transform/processor/GroovyTransformProcessorProperties.java
+++ b/processor/spring-cloud-starter-stream-processor-groovy-transform/src/main/java/org/springframework/cloud/stream/app/groovy/transform/processor/GroovyTransformProcessorProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/processor/spring-cloud-starter-stream-processor-groovy-transform/src/main/java/org/springframework/cloud/stream/app/groovy/transform/processor/ScriptVariableGeneratorConfiguration.java
+++ b/processor/spring-cloud-starter-stream-processor-groovy-transform/src/main/java/org/springframework/cloud/stream/app/groovy/transform/processor/ScriptVariableGeneratorConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/processor/spring-cloud-starter-stream-processor-groovy-transform/src/test/java/org/springframework/cloud/stream/app/groovy/transform/processor/GroovyTransformProcessorIntegrationTests.java
+++ b/processor/spring-cloud-starter-stream-processor-groovy-transform/src/test/java/org/springframework/cloud/stream/app/groovy/transform/processor/GroovyTransformProcessorIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/processor/spring-cloud-starter-stream-processor-httpclient/src/main/java/org/springframework/cloud/stream/app/httpclient/processor/HttpclientProcessorConfiguration.java
+++ b/processor/spring-cloud-starter-stream-processor-httpclient/src/main/java/org/springframework/cloud/stream/app/httpclient/processor/HttpclientProcessorConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/processor/spring-cloud-starter-stream-processor-httpclient/src/main/java/org/springframework/cloud/stream/app/httpclient/processor/HttpclientProcessorProperties.java
+++ b/processor/spring-cloud-starter-stream-processor-httpclient/src/main/java/org/springframework/cloud/stream/app/httpclient/processor/HttpclientProcessorProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/processor/spring-cloud-starter-stream-processor-httpclient/src/test/java/org/springframework/cloud/stream/app/httpclient/processor/HttpClientProcessorTests.java
+++ b/processor/spring-cloud-starter-stream-processor-httpclient/src/test/java/org/springframework/cloud/stream/app/httpclient/processor/HttpClientProcessorTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/processor/spring-cloud-starter-stream-processor-pmml/src/main/java/org/springframework/cloud/stream/app/pmml/processor/CustomConversionServiceRegistrar.java
+++ b/processor/spring-cloud-starter-stream-processor-pmml/src/main/java/org/springframework/cloud/stream/app/pmml/processor/CustomConversionServiceRegistrar.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/processor/spring-cloud-starter-stream-processor-pmml/src/main/java/org/springframework/cloud/stream/app/pmml/processor/GenericMapConverter.java
+++ b/processor/spring-cloud-starter-stream-processor-pmml/src/main/java/org/springframework/cloud/stream/app/pmml/processor/GenericMapConverter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/processor/spring-cloud-starter-stream-processor-pmml/src/main/java/org/springframework/cloud/stream/app/pmml/processor/PmmlProcessorConfiguration.java
+++ b/processor/spring-cloud-starter-stream-processor-pmml/src/main/java/org/springframework/cloud/stream/app/pmml/processor/PmmlProcessorConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/processor/spring-cloud-starter-stream-processor-pmml/src/main/java/org/springframework/cloud/stream/app/pmml/processor/PmmlProcessorProperties.java
+++ b/processor/spring-cloud-starter-stream-processor-pmml/src/main/java/org/springframework/cloud/stream/app/pmml/processor/PmmlProcessorProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/processor/spring-cloud-starter-stream-processor-pmml/src/test/java/org/springframework/cloud/stream/app/pmml/processor/GenericMapConverterTests.java
+++ b/processor/spring-cloud-starter-stream-processor-pmml/src/test/java/org/springframework/cloud/stream/app/pmml/processor/GenericMapConverterTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/processor/spring-cloud-starter-stream-processor-pmml/src/test/java/org/springframework/cloud/stream/app/pmml/processor/PmmlProcessorIntegrationTests.java
+++ b/processor/spring-cloud-starter-stream-processor-pmml/src/test/java/org/springframework/cloud/stream/app/pmml/processor/PmmlProcessorIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/processor/spring-cloud-starter-stream-processor-scriptable-transform/src/main/java/org/springframework/cloud/stream/app/scriptable/transform/processor/ScriptVariableGeneratorConfiguration.java
+++ b/processor/spring-cloud-starter-stream-processor-scriptable-transform/src/main/java/org/springframework/cloud/stream/app/scriptable/transform/processor/ScriptVariableGeneratorConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/processor/spring-cloud-starter-stream-processor-scriptable-transform/src/main/java/org/springframework/cloud/stream/app/scriptable/transform/processor/ScriptableTransformProcessorConfiguration.java
+++ b/processor/spring-cloud-starter-stream-processor-scriptable-transform/src/main/java/org/springframework/cloud/stream/app/scriptable/transform/processor/ScriptableTransformProcessorConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/processor/spring-cloud-starter-stream-processor-scriptable-transform/src/main/java/org/springframework/cloud/stream/app/scriptable/transform/processor/ScriptableTransformProcessorProperties.java
+++ b/processor/spring-cloud-starter-stream-processor-scriptable-transform/src/main/java/org/springframework/cloud/stream/app/scriptable/transform/processor/ScriptableTransformProcessorProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/processor/spring-cloud-starter-stream-processor-scriptable-transform/src/test/java/org/springframework/cloud/stream/app/scriptable/transform/processor/ScriptableTransformProcessorIntegrationTests.java
+++ b/processor/spring-cloud-starter-stream-processor-scriptable-transform/src/test/java/org/springframework/cloud/stream/app/scriptable/transform/processor/ScriptableTransformProcessorIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/processor/spring-cloud-starter-stream-processor-splitter/src/main/java/org/springframework/cloud/stream/app/splitter/processor/SplitterProcessorConfiguration.java
+++ b/processor/spring-cloud-starter-stream-processor-splitter/src/main/java/org/springframework/cloud/stream/app/splitter/processor/SplitterProcessorConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/processor/spring-cloud-starter-stream-processor-splitter/src/main/java/org/springframework/cloud/stream/app/splitter/processor/SplitterProcessorProperties.java
+++ b/processor/spring-cloud-starter-stream-processor-splitter/src/main/java/org/springframework/cloud/stream/app/splitter/processor/SplitterProcessorProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/processor/spring-cloud-starter-stream-processor-splitter/src/test/java/org/springframework/cloud/stream/app/splitter/processor/SplitterProcessorIntegrationTests.java
+++ b/processor/spring-cloud-starter-stream-processor-splitter/src/test/java/org/springframework/cloud/stream/app/splitter/processor/SplitterProcessorIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/processor/spring-cloud-starter-stream-processor-transform/src/main/java/org/springframework/cloud/stream/app/transform/processor/TransformProcessorConfiguration.java
+++ b/processor/spring-cloud-starter-stream-processor-transform/src/main/java/org/springframework/cloud/stream/app/transform/processor/TransformProcessorConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/processor/spring-cloud-starter-stream-processor-transform/src/main/java/org/springframework/cloud/stream/app/transform/processor/TransformProcessorProperties.java
+++ b/processor/spring-cloud-starter-stream-processor-transform/src/main/java/org/springframework/cloud/stream/app/transform/processor/TransformProcessorProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/processor/spring-cloud-starter-stream-processor-transform/src/test/java/org/springframework/cloud/stream/app/transform/processor/TransformProcessorIntegrationTests.java
+++ b/processor/spring-cloud-starter-stream-processor-transform/src/test/java/org/springframework/cloud/stream/app/transform/processor/TransformProcessorIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/rabbit/spring-cloud-starter-stream-sink-rabbit/src/main/java/org/springframework/cloud/stream/app/rabbit/sink/RabbitSinkConfiguration.java
+++ b/rabbit/spring-cloud-starter-stream-sink-rabbit/src/main/java/org/springframework/cloud/stream/app/rabbit/sink/RabbitSinkConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/rabbit/spring-cloud-starter-stream-sink-rabbit/src/main/java/org/springframework/cloud/stream/app/rabbit/sink/RabbitSinkProperties.java
+++ b/rabbit/spring-cloud-starter-stream-sink-rabbit/src/main/java/org/springframework/cloud/stream/app/rabbit/sink/RabbitSinkProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/rabbit/spring-cloud-starter-stream-sink-rabbit/src/test/java/org/springframework/cloud/stream/app/rabbit/sink/RabbitSinkInvalidConfigTests.java
+++ b/rabbit/spring-cloud-starter-stream-sink-rabbit/src/test/java/org/springframework/cloud/stream/app/rabbit/sink/RabbitSinkInvalidConfigTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/rabbit/spring-cloud-starter-stream-sink-rabbit/src/test/java/org/springframework/cloud/stream/app/rabbit/sink/RabbitSinkTests.java
+++ b/rabbit/spring-cloud-starter-stream-sink-rabbit/src/test/java/org/springframework/cloud/stream/app/rabbit/sink/RabbitSinkTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/rabbit/spring-cloud-starter-stream-source-rabbit/src/main/java/org/springframework/cloud/stream/app/rabbit/source/RabbitSourceConfiguration.java
+++ b/rabbit/spring-cloud-starter-stream-source-rabbit/src/main/java/org/springframework/cloud/stream/app/rabbit/source/RabbitSourceConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/rabbit/spring-cloud-starter-stream-source-rabbit/src/main/java/org/springframework/cloud/stream/app/rabbit/source/RabbitSourceProperties.java
+++ b/rabbit/spring-cloud-starter-stream-source-rabbit/src/main/java/org/springframework/cloud/stream/app/rabbit/source/RabbitSourceProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/rabbit/spring-cloud-starter-stream-source-rabbit/src/test/java/org/springframework/cloud/stream/app/rabbit/source/RabbitSourceInvalidConfigTests.java
+++ b/rabbit/spring-cloud-starter-stream-source-rabbit/src/test/java/org/springframework/cloud/stream/app/rabbit/source/RabbitSourceInvalidConfigTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/rabbit/spring-cloud-starter-stream-source-rabbit/src/test/java/org/springframework/cloud/stream/app/rabbit/source/RabbitSourceTests.java
+++ b/rabbit/spring-cloud-starter-stream-source-rabbit/src/test/java/org/springframework/cloud/stream/app/rabbit/source/RabbitSourceTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/redis/spring-cloud-starter-stream-sink-redis/src/main/java/org/springframework/cloud/stream/app/redis/sink/RedisSinkConfiguration.java
+++ b/redis/spring-cloud-starter-stream-sink-redis/src/main/java/org/springframework/cloud/stream/app/redis/sink/RedisSinkConfiguration.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/redis/spring-cloud-starter-stream-sink-redis/src/main/java/org/springframework/cloud/stream/app/redis/sink/RedisSinkProperties.java
+++ b/redis/spring-cloud-starter-stream-sink-redis/src/main/java/org/springframework/cloud/stream/app/redis/sink/RedisSinkProperties.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/redis/spring-cloud-starter-stream-sink-redis/src/test/java/org/springframework/cloud/stream/app/redis/sink/RedisSinkApplicationTests.java
+++ b/redis/spring-cloud-starter-stream-sink-redis/src/test/java/org/springframework/cloud/stream/app/redis/sink/RedisSinkApplicationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/router/spring-cloud-starter-stream-sink-router/src/main/java/org/springframework/cloud/stream/app/router/sink/RouterSinkConfiguration.java
+++ b/router/spring-cloud-starter-stream-sink-router/src/main/java/org/springframework/cloud/stream/app/router/sink/RouterSinkConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/router/spring-cloud-starter-stream-sink-router/src/main/java/org/springframework/cloud/stream/app/router/sink/RouterSinkProperties.java
+++ b/router/spring-cloud-starter-stream-sink-router/src/main/java/org/springframework/cloud/stream/app/router/sink/RouterSinkProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/router/spring-cloud-starter-stream-sink-router/src/main/java/org/springframework/cloud/stream/app/router/sink/ScriptVariableGeneratorConfiguration.java
+++ b/router/spring-cloud-starter-stream-sink-router/src/main/java/org/springframework/cloud/stream/app/router/sink/ScriptVariableGeneratorConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/router/spring-cloud-starter-stream-sink-router/src/test/java/org/springframework/cloud/stream/app/router/sink/RouterSinkTests.java
+++ b/router/spring-cloud-starter-stream-sink-router/src/test/java/org/springframework/cloud/stream/app/router/sink/RouterSinkTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/sftp/spring-cloud-starter-stream-sink-sftp/src/main/java/org/springframework/cloud/stream/app/sftp/sink/SftpSinkConfiguration.java
+++ b/sftp/spring-cloud-starter-stream-sink-sftp/src/main/java/org/springframework/cloud/stream/app/sftp/sink/SftpSinkConfiguration.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/sftp/spring-cloud-starter-stream-sink-sftp/src/main/java/org/springframework/cloud/stream/app/sftp/sink/SftpSinkProperties.java
+++ b/sftp/spring-cloud-starter-stream-sink-sftp/src/main/java/org/springframework/cloud/stream/app/sftp/sink/SftpSinkProperties.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/sftp/spring-cloud-starter-stream-sink-sftp/src/test/java/org/springframework/cloud/stream/app/sftp/sink/SftpSinkIntegrationTests.java
+++ b/sftp/spring-cloud-starter-stream-sink-sftp/src/test/java/org/springframework/cloud/stream/app/sftp/sink/SftpSinkIntegrationTests.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/sftp/spring-cloud-starter-stream-sink-sftp/src/test/java/org/springframework/cloud/stream/app/sftp/sink/SftpSinkPropertiesTests.java
+++ b/sftp/spring-cloud-starter-stream-sink-sftp/src/test/java/org/springframework/cloud/stream/app/sftp/sink/SftpSinkPropertiesTests.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/sftp/spring-cloud-starter-stream-source-sftp/src/main/java/org/springframework/cloud/stream/app/sftp/source/SftpSourceConfiguration.java
+++ b/sftp/spring-cloud-starter-stream-source-sftp/src/main/java/org/springframework/cloud/stream/app/sftp/source/SftpSourceConfiguration.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/sftp/spring-cloud-starter-stream-source-sftp/src/main/java/org/springframework/cloud/stream/app/sftp/source/SftpSourceProperties.java
+++ b/sftp/spring-cloud-starter-stream-source-sftp/src/main/java/org/springframework/cloud/stream/app/sftp/source/SftpSourceProperties.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/sftp/spring-cloud-starter-stream-source-sftp/src/test/java/org/springframework/cloud/stream/app/sftp/source/SftpSourceIntegrationTests.java
+++ b/sftp/spring-cloud-starter-stream-source-sftp/src/test/java/org/springframework/cloud/stream/app/sftp/source/SftpSourceIntegrationTests.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/sftp/spring-cloud-starter-stream-source-sftp/src/test/java/org/springframework/cloud/stream/app/sftp/source/SftpSourcePropertiesTests.java
+++ b/sftp/spring-cloud-starter-stream-source-sftp/src/test/java/org/springframework/cloud/stream/app/sftp/source/SftpSourcePropertiesTests.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-stream-app-documentation-maven-plugin/src/main/java/org/springframework/cloud/stream/app/documentation/plugin/ConfigurationMetadataDocumentationMojo.java
+++ b/spring-cloud-stream-app-documentation-maven-plugin/src/main/java/org/springframework/cloud/stream/app/documentation/plugin/ConfigurationMetadataDocumentationMojo.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-stream-app-starters-docs/src/main/docbook/xsl/common.xsl
+++ b/spring-cloud-stream-app-starters-docs/src/main/docbook/xsl/common.xsl
@@ -9,7 +9,7 @@
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+   https://www.apache.org/licenses/LICENSE-2.0
 
  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an

--- a/spring-cloud-stream-app-starters-docs/src/main/docbook/xsl/epub.xsl
+++ b/spring-cloud-stream-app-starters-docs/src/main/docbook/xsl/epub.xsl
@@ -9,7 +9,7 @@ to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an

--- a/spring-cloud-stream-app-starters-docs/src/main/docbook/xsl/html-multipage.xsl
+++ b/spring-cloud-stream-app-starters-docs/src/main/docbook/xsl/html-multipage.xsl
@@ -9,7 +9,7 @@ to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an

--- a/spring-cloud-stream-app-starters-docs/src/main/docbook/xsl/html-singlepage.xsl
+++ b/spring-cloud-stream-app-starters-docs/src/main/docbook/xsl/html-singlepage.xsl
@@ -9,7 +9,7 @@ to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an

--- a/spring-cloud-stream-app-starters-docs/src/main/docbook/xsl/html.xsl
+++ b/spring-cloud-stream-app-starters-docs/src/main/docbook/xsl/html.xsl
@@ -9,7 +9,7 @@ to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an

--- a/spring-cloud-stream-app-starters-docs/src/main/docbook/xsl/pdf.xsl
+++ b/spring-cloud-stream-app-starters-docs/src/main/docbook/xsl/pdf.xsl
@@ -9,7 +9,7 @@ to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an

--- a/syslog/spring-cloud-starter-stream-source-syslog/src/main/java/org/springframework/cloud/stream/app/syslog/source/SyslogSourceConfiguration.java
+++ b/syslog/spring-cloud-starter-stream-source-syslog/src/main/java/org/springframework/cloud/stream/app/syslog/source/SyslogSourceConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/syslog/spring-cloud-starter-stream-source-syslog/src/main/java/org/springframework/cloud/stream/app/syslog/source/SyslogSourceProperties.java
+++ b/syslog/spring-cloud-starter-stream-source-syslog/src/main/java/org/springframework/cloud/stream/app/syslog/source/SyslogSourceProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/syslog/spring-cloud-starter-stream-source-syslog/src/main/resources/static/index.html
+++ b/syslog/spring-cloud-starter-stream-source-syslog/src/main/resources/static/index.html
@@ -6,7 +6,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/syslog/spring-cloud-starter-stream-source-syslog/src/test/java/org/springframework/cloud/stream/app/syslog/source/SyslogSourceTests.java
+++ b/syslog/spring-cloud-starter-stream-source-syslog/src/test/java/org/springframework/cloud/stream/app/syslog/source/SyslogSourceTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/tasklauncher/spring-cloud-starter-stream-sink-tasklauncher-local/src/main/java/org/springframework/cloud/stream/app/task/launcher/local/sink/TaskLauncherLocalSinkConfiguration.java
+++ b/tasklauncher/spring-cloud-starter-stream-sink-tasklauncher-local/src/main/java/org/springframework/cloud/stream/app/task/launcher/local/sink/TaskLauncherLocalSinkConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/tasklauncher/spring-cloud-starter-stream-sink-tasklauncher-local/src/test/java/org/springframework/cloud/stream/app/task/launcher/local/sink/TaskLauncherLocalSinkIntegrationTests.java
+++ b/tasklauncher/spring-cloud-starter-stream-sink-tasklauncher-local/src/test/java/org/springframework/cloud/stream/app/task/launcher/local/sink/TaskLauncherLocalSinkIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/tasklauncher/spring-cloud-starter-stream-sink-tasklauncher-local/src/test/java/org/springframework/cloud/stream/app/task/launcher/local/sink/configuration/TaskSinkConfiguration.java
+++ b/tasklauncher/spring-cloud-starter-stream-sink-tasklauncher-local/src/test/java/org/springframework/cloud/stream/app/task/launcher/local/sink/configuration/TaskSinkConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/tcp/spring-cloud-starter-stream-processor-tcp-client/src/main/java/org/springframework/cloud/stream/app/tcp/client/processor/TcpClientProcessorConfiguration.java
+++ b/tcp/spring-cloud-starter-stream-processor-tcp-client/src/main/java/org/springframework/cloud/stream/app/tcp/client/processor/TcpClientProcessorConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/tcp/spring-cloud-starter-stream-processor-tcp-client/src/main/java/org/springframework/cloud/stream/app/tcp/client/processor/TcpClientProcessorProperties.java
+++ b/tcp/spring-cloud-starter-stream-processor-tcp-client/src/main/java/org/springframework/cloud/stream/app/tcp/client/processor/TcpClientProcessorProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/tcp/spring-cloud-starter-stream-processor-tcp-client/src/test/java/org/springframework/cloud/stream/app/tcp/client/processor/TcpClientTests.java
+++ b/tcp/spring-cloud-starter-stream-processor-tcp-client/src/test/java/org/springframework/cloud/stream/app/tcp/client/processor/TcpClientTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/tcp/spring-cloud-starter-stream-sink-tcp/src/main/java/org/springframework/cloud/stream/app/tcp/sink/TcpSinkConfiguration.java
+++ b/tcp/spring-cloud-starter-stream-sink-tcp/src/main/java/org/springframework/cloud/stream/app/tcp/sink/TcpSinkConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/tcp/spring-cloud-starter-stream-sink-tcp/src/main/java/org/springframework/cloud/stream/app/tcp/sink/TcpSinkProperties.java
+++ b/tcp/spring-cloud-starter-stream-sink-tcp/src/main/java/org/springframework/cloud/stream/app/tcp/sink/TcpSinkProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/tcp/spring-cloud-starter-stream-sink-tcp/src/test/java/org/springframework/cloud/stream/app/tcp/sink/TcpSinkTests.java
+++ b/tcp/spring-cloud-starter-stream-sink-tcp/src/test/java/org/springframework/cloud/stream/app/tcp/sink/TcpSinkTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/tcp/spring-cloud-starter-stream-source-tcp-client/src/main/java/org/springframework/cloud/stream/app/tcp/client/source/TcpClientSourceConfiguration.java
+++ b/tcp/spring-cloud-starter-stream-source-tcp-client/src/main/java/org/springframework/cloud/stream/app/tcp/client/source/TcpClientSourceConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/tcp/spring-cloud-starter-stream-source-tcp-client/src/main/java/org/springframework/cloud/stream/app/tcp/client/source/TcpClientSourceProperties.java
+++ b/tcp/spring-cloud-starter-stream-source-tcp-client/src/main/java/org/springframework/cloud/stream/app/tcp/client/source/TcpClientSourceProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/tcp/spring-cloud-starter-stream-source-tcp-client/src/test/java/org/springframework/cloud/stream/app/tcp/client/source/TcpClientTests.java
+++ b/tcp/spring-cloud-starter-stream-source-tcp-client/src/test/java/org/springframework/cloud/stream/app/tcp/client/source/TcpClientTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/tcp/spring-cloud-starter-stream-source-tcp/src/main/java/org/springframework/cloud/stream/app/tcp/source/TcpSourceConfiguration.java
+++ b/tcp/spring-cloud-starter-stream-source-tcp/src/main/java/org/springframework/cloud/stream/app/tcp/source/TcpSourceConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/tcp/spring-cloud-starter-stream-source-tcp/src/main/java/org/springframework/cloud/stream/app/tcp/source/TcpSourceProperties.java
+++ b/tcp/spring-cloud-starter-stream-source-tcp/src/main/java/org/springframework/cloud/stream/app/tcp/source/TcpSourceProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/tcp/spring-cloud-starter-stream-source-tcp/src/test/org/springframework/cloud/stream/app/tcp/source/TcpSourceTests.java
+++ b/tcp/spring-cloud-starter-stream-source-tcp/src/test/org/springframework/cloud/stream/app/tcp/source/TcpSourceTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/testing/spring-cloud-starter-stream-processor-integration-test/src/main/java/org/springframework/cloud/stream/app/integration/test/processor/IntegrationTestProcessorConfiguration.java
+++ b/testing/spring-cloud-starter-stream-processor-integration-test/src/main/java/org/springframework/cloud/stream/app/integration/test/processor/IntegrationTestProcessorConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/testing/spring-cloud-starter-stream-processor-integration-test/src/main/java/org/springframework/cloud/stream/app/integration/test/processor/IntegrationTestProcessorProperties.java
+++ b/testing/spring-cloud-starter-stream-processor-integration-test/src/main/java/org/springframework/cloud/stream/app/integration/test/processor/IntegrationTestProcessorProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/testing/spring-cloud-starter-stream-processor-integration-test/src/test/java/org/springframework/cloud/stream/app/integration/test/processor/IntegrationTestProcessorTests.java
+++ b/testing/spring-cloud-starter-stream-processor-integration-test/src/test/java/org/springframework/cloud/stream/app/integration/test/processor/IntegrationTestProcessorTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/testing/spring-cloud-starter-stream-sink-throughput/src/main/java/org/springframework/cloud/stream/app/throughput/sink/ThroughputSinkConfiguration.java
+++ b/testing/spring-cloud-starter-stream-sink-throughput/src/main/java/org/springframework/cloud/stream/app/throughput/sink/ThroughputSinkConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/testing/spring-cloud-starter-stream-sink-throughput/src/main/java/org/springframework/cloud/stream/app/throughput/sink/ThroughputSinkProperties.java
+++ b/testing/spring-cloud-starter-stream-sink-throughput/src/main/java/org/springframework/cloud/stream/app/throughput/sink/ThroughputSinkProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/testing/spring-cloud-starter-stream-sink-throughput/src/main/java/org/springframework/cloud/stream/app/throughput/sink/TimeUnit.java
+++ b/testing/spring-cloud-starter-stream-sink-throughput/src/main/java/org/springframework/cloud/stream/app/throughput/sink/TimeUnit.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/testing/spring-cloud-starter-stream-sink-throughput/src/test/java/org/springframework/cloud/stream/app/throughput/sink/ThroughputSinkTests.java
+++ b/testing/spring-cloud-starter-stream-sink-throughput/src/test/java/org/springframework/cloud/stream/app/throughput/sink/ThroughputSinkTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/testing/spring-cloud-starter-stream-source-load-generator/src/main/java/org/springframework/cloud/stream/app/load/generator/source/LoadGeneratorSourceConfiguration.java
+++ b/testing/spring-cloud-starter-stream-source-load-generator/src/main/java/org/springframework/cloud/stream/app/load/generator/source/LoadGeneratorSourceConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/testing/spring-cloud-starter-stream-source-load-generator/src/main/java/org/springframework/cloud/stream/app/load/generator/source/LoadGeneratorSourceProperties.java
+++ b/testing/spring-cloud-starter-stream-source-load-generator/src/main/java/org/springframework/cloud/stream/app/load/generator/source/LoadGeneratorSourceProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/testing/spring-cloud-starter-stream-source-load-generator/src/test/java/org/springframework/cloud/stream/app/load/generator/source/LoadGeneratorSourceTests.java
+++ b/testing/spring-cloud-starter-stream-source-load-generator/src/test/java/org/springframework/cloud/stream/app/load/generator/source/LoadGeneratorSourceTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/time/spring-cloud-starter-stream-source-time/src/main/java/org/springframework/cloud/stream/app/time/source/TimeSourceConfiguration.java
+++ b/time/spring-cloud-starter-stream-source-time/src/main/java/org/springframework/cloud/stream/app/time/source/TimeSourceConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/time/spring-cloud-starter-stream-source-time/src/test/java/org/springframework/cloud/stream/app/time/source/TimeSourceIntegrationTests.java
+++ b/time/spring-cloud-starter-stream-source-time/src/test/java/org/springframework/cloud/stream/app/time/source/TimeSourceIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/trigger/spring-cloud-starter-stream-source-trigger/src/main/java/org/springframework/cloud/stream/app/trigger/source/TriggerSourceConfiguration.java
+++ b/trigger/spring-cloud-starter-stream-source-trigger/src/main/java/org/springframework/cloud/stream/app/trigger/source/TriggerSourceConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/trigger/spring-cloud-starter-stream-source-trigger/src/test/java/org/springframework/cloud/stream/app/trigger/source/TriggerSourceTests.java
+++ b/trigger/spring-cloud-starter-stream-source-trigger/src/test/java/org/springframework/cloud/stream/app/trigger/source/TriggerSourceTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/triggertask/spring-cloud-starter-stream-source-triggertask/src/main/java/org/springframework/cloud/stream/app/triggertask/source/TaskPayloadProperties.java
+++ b/triggertask/spring-cloud-starter-stream-source-triggertask/src/main/java/org/springframework/cloud/stream/app/triggertask/source/TaskPayloadProperties.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/triggertask/spring-cloud-starter-stream-source-triggertask/src/main/java/org/springframework/cloud/stream/app/triggertask/source/TriggertaskSourceConfiguration.java
+++ b/triggertask/spring-cloud-starter-stream-source-triggertask/src/main/java/org/springframework/cloud/stream/app/triggertask/source/TriggertaskSourceConfiguration.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/triggertask/spring-cloud-starter-stream-source-triggertask/src/main/java/org/springframework/cloud/stream/app/triggertask/source/arguments/CommandLineArgumentTransformer.java
+++ b/triggertask/spring-cloud-starter-stream-source-triggertask/src/main/java/org/springframework/cloud/stream/app/triggertask/source/arguments/CommandLineArgumentTransformer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/triggertask/spring-cloud-starter-stream-source-triggertask/src/main/java/org/springframework/cloud/stream/app/triggertask/source/arguments/PassThroughCommandLineArgumentTransformer.java
+++ b/triggertask/spring-cloud-starter-stream-source-triggertask/src/main/java/org/springframework/cloud/stream/app/triggertask/source/arguments/PassThroughCommandLineArgumentTransformer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/triggertask/spring-cloud-starter-stream-source-triggertask/src/test/java/org/springframework/cloud/stream/app/triggertask/source/TriggertaskSourceTests.java
+++ b/triggertask/spring-cloud-starter-stream-source-triggertask/src/test/java/org/springframework/cloud/stream/app/triggertask/source/TriggertaskSourceTests.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/triggertask/spring-cloud-starter-stream-source-triggertask/src/test/java/org/springframework/cloud/stream/app/triggertask/source/arguments/PassThroughCommandLineArgumentTransformerTests.java
+++ b/triggertask/spring-cloud-starter-stream-source-triggertask/src/test/java/org/springframework/cloud/stream/app/triggertask/source/arguments/PassThroughCommandLineArgumentTransformerTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/twitter/spring-cloud-starter-stream-source-twitterstream/src/main/java/org/springframework/cloud/stream/app/twitterstream/source/AbstractTwitterInboundChannelAdapter.java
+++ b/twitter/spring-cloud-starter-stream-source-twitterstream/src/main/java/org/springframework/cloud/stream/app/twitterstream/source/AbstractTwitterInboundChannelAdapter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/twitter/spring-cloud-starter-stream-source-twitterstream/src/main/java/org/springframework/cloud/stream/app/twitterstream/source/TwitterStreamMessageProducer.java
+++ b/twitter/spring-cloud-starter-stream-source-twitterstream/src/main/java/org/springframework/cloud/stream/app/twitterstream/source/TwitterStreamMessageProducer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/twitter/spring-cloud-starter-stream-source-twitterstream/src/main/java/org/springframework/cloud/stream/app/twitterstream/source/TwitterStreamProperties.java
+++ b/twitter/spring-cloud-starter-stream-source-twitterstream/src/main/java/org/springframework/cloud/stream/app/twitterstream/source/TwitterStreamProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/twitter/spring-cloud-starter-stream-source-twitterstream/src/main/java/org/springframework/cloud/stream/app/twitterstream/source/TwitterStreamType.java
+++ b/twitter/spring-cloud-starter-stream-source-twitterstream/src/main/java/org/springframework/cloud/stream/app/twitterstream/source/TwitterStreamType.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/twitter/spring-cloud-starter-stream-source-twitterstream/src/main/java/org/springframework/cloud/stream/app/twitterstream/source/TwitterstreamSourceConfiguration.java
+++ b/twitter/spring-cloud-starter-stream-source-twitterstream/src/main/java/org/springframework/cloud/stream/app/twitterstream/source/TwitterstreamSourceConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/twitter/spring-cloud-starter-stream-source-twitterstream/src/test/java/org/springframework/cloud/stream/app/twitterstream/source/TwitterSourceIntegrationTests.java
+++ b/twitter/spring-cloud-starter-stream-source-twitterstream/src/test/java/org/springframework/cloud/stream/app/twitterstream/source/TwitterSourceIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/websocket/spring-cloud-starter-stream-sink-websocket/src/main/java/org/springframework/cloud/stream/app/websocket/sink/WebsocketSinkConfiguration.java
+++ b/websocket/spring-cloud-starter-stream-sink-websocket/src/main/java/org/springframework/cloud/stream/app/websocket/sink/WebsocketSinkConfiguration.java
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/websocket/spring-cloud-starter-stream-sink-websocket/src/main/java/org/springframework/cloud/stream/app/websocket/sink/WebsocketSinkProperties.java
+++ b/websocket/spring-cloud-starter-stream-sink-websocket/src/main/java/org/springframework/cloud/stream/app/websocket/sink/WebsocketSinkProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/websocket/spring-cloud-starter-stream-sink-websocket/src/main/java/org/springframework/cloud/stream/app/websocket/sink/WebsocketSinkServer.java
+++ b/websocket/spring-cloud-starter-stream-sink-websocket/src/main/java/org/springframework/cloud/stream/app/websocket/sink/WebsocketSinkServer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/websocket/spring-cloud-starter-stream-sink-websocket/src/main/java/org/springframework/cloud/stream/app/websocket/sink/WebsocketSinkServerHandler.java
+++ b/websocket/spring-cloud-starter-stream-sink-websocket/src/main/java/org/springframework/cloud/stream/app/websocket/sink/WebsocketSinkServerHandler.java
@@ -5,7 +5,7 @@
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/websocket/spring-cloud-starter-stream-sink-websocket/src/main/java/org/springframework/cloud/stream/app/websocket/sink/WebsocketSinkServerInitializer.java
+++ b/websocket/spring-cloud-starter-stream-sink-websocket/src/main/java/org/springframework/cloud/stream/app/websocket/sink/WebsocketSinkServerInitializer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/websocket/spring-cloud-starter-stream-sink-websocket/src/main/java/org/springframework/cloud/stream/app/websocket/sink/actuator/WebsocketSinkTraceEndpoint.java
+++ b/websocket/spring-cloud-starter-stream-sink-websocket/src/main/java/org/springframework/cloud/stream/app/websocket/sink/actuator/WebsocketSinkTraceEndpoint.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/websocket/spring-cloud-starter-stream-sink-websocket/src/test/java/org/springframework/cloud/stream/app/websocket/sink/WebsocketSinkIntegrationTests.java
+++ b/websocket/spring-cloud-starter-stream-sink-websocket/src/test/java/org/springframework/cloud/stream/app/websocket/sink/WebsocketSinkIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/ with 1 occurrences migrated to:  
  https://www.apache.org/licenses/ ([https](https://www.apache.org/licenses/) result 200).
* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 321 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).